### PR TITLE
fix(build): preserve CODESIGN_IDENTITY from CI environment

### DIFF
--- a/.changeset/fix-codesign-identity.md
+++ b/.changeset/fix-codesign-identity.md
@@ -1,0 +1,9 @@
+---
+"think-app": patch
+---
+
+fix(build): preserve CODESIGN_IDENTITY from CI environment
+
+The build:backend script was overwriting the CODESIGN_IDENTITY environment variable by reading from .env.local (which doesn't exist in CI). This caused dylib signing to be skipped, resulting in "Python.framework is damaged" Gatekeeper errors when opening the app downloaded from GitHub releases.
+
+Changed from `export CODESIGN_IDENTITY="$(grep ...)"` to `CODESIGN_IDENTITY="${CODESIGN_IDENTITY:-$(grep ...)}"` to preserve the CI-provided environment variable.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "app": "pnpm --filter think-app dev",
     "ext": "pnpm --filter think-extension build",
     "backend": "cd backend && poetry run uvicorn app.main:app --reload --port 8765",
-    "build:backend": "export CODESIGN_IDENTITY=\"$(grep '^CODESIGN_IDENTITY=' .env.local 2>/dev/null | cut -d= -f2-)\"; cd backend && poetry run pyinstaller think.spec --clean && [ -n \"$CODESIGN_IDENTITY\" ] && find dist/think-backend \\( -name '*.dylib' -o -name '*.so' \\) -exec codesign --force --sign \"$CODESIGN_IDENTITY\" --timestamp --options runtime {} \\; || echo 'Skipping dylib signing (CODESIGN_IDENTITY not set)'",
+    "build:backend": "CODESIGN_IDENTITY=\"${CODESIGN_IDENTITY:-$(grep '^CODESIGN_IDENTITY=' .env.local 2>/dev/null | cut -d= -f2- || echo '')}\"; cd backend && poetry run pyinstaller think.spec --clean && [ -n \"$CODESIGN_IDENTITY\" ] && find dist/think-backend \\( -name '*.dylib' -o -name '*.so' \\) -exec codesign --force --sign \"$CODESIGN_IDENTITY\" --timestamp --options runtime {} \\; || echo 'Skipping dylib signing (CODESIGN_IDENTITY not set)'",
     "build:stub": "cd backend/native_host && clang -O2 -o think-native-stub stub_launcher.c && codesign --sign - --force think-native-stub",
     "build:app": "pnpm --filter think-app build && pnpm --filter think-app electron:build",
     "build:app:release": "pnpm --filter think-app build && pnpm --filter think-app electron:build:release",


### PR DESCRIPTION
## Summary
- Fix `build:backend` script to preserve `CODESIGN_IDENTITY` environment variable from CI
- The script was overwriting it by reading from `.env.local` (which doesn't exist in CI)
- This caused dylib signing to be skipped, resulting in Gatekeeper errors

## Test plan
- [ ] Merge to main
- [ ] Merge the resulting Version Packages PR
- [ ] Verify the new release DMG opens without Gatekeeper warnings