### PR TITLE
fix(build): sign Python.framework to resolve macOS damage error

### DIFF
--- a/.changeset/fix-python-framework-signing.md
+++ b/.changeset/fix-python-framework-signing.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+Fix Python.framework code signing to resolve "damaged" error on macOS

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "app": "pnpm --filter think-app dev",
     "ext": "pnpm --filter think-extension build",
     "backend": "cd backend && poetry run uvicorn app.main:app --reload --port 8765",
-    "build:backend": "export CODESIGN_IDENTITY=\"${CODESIGN_IDENTITY:-$(grep '^CODESIGN_IDENTITY=' .env.local 2>/dev/null | cut -d= -f2-)}\"; cd backend && poetry run pyinstaller think.spec --clean && [ -n \"$CODESIGN_IDENTITY\" ] && find dist/think-backend \\( -name '*.dylib' -o -name '*.so' \\) -exec codesign --force --sign \"$CODESIGN_IDENTITY\" --timestamp --options runtime {} \\; || echo 'Skipping dylib signing (CODESIGN_IDENTITY not set)'",
+    "build:backend": "export CODESIGN_IDENTITY=\"${CODESIGN_IDENTITY:-$(grep '^CODESIGN_IDENTITY=' .env.local 2>/dev/null | cut -d= -f2-)}\"; cd backend && poetry run pyinstaller think.spec --clean && [ -n \"$CODESIGN_IDENTITY\" ] && { find dist/think-backend \\( -name '*.dylib' -o -name '*.so' \\) -exec codesign --force --sign \"$CODESIGN_IDENTITY\" --timestamp --options runtime {} \\; ; codesign --deep --force --sign \"$CODESIGN_IDENTITY\" --timestamp --options runtime --entitlements entitlements.plist dist/think-backend/Python.framework; } || echo 'Skipping signing (CODESIGN_IDENTITY not set)'",
     "build:stub": "cd backend/native_host && clang -O2 -o think-native-stub stub_launcher.c && codesign --sign - --force think-native-stub",
     "build:app": "pnpm --filter think-app build && pnpm --filter think-app electron:build",
     "build:app:release": "pnpm --filter think-app build && pnpm --filter think-app electron:build:release",


### PR DESCRIPTION
## Summary
- Adds explicit signing of `Python.framework` bundled by PyInstaller
- Uses `--deep` flag to recursively sign all nested binaries
- Includes entitlements for Python JIT memory requirements

The previous fix (#4) preserved `CODESIGN_IDENTITY` in CI but the build script only signed `.dylib` and `.so` files. `Python.framework` was left unsigned, causing "Python.framework is damaged" errors on macOS.

## Test plan
- [ ] Build locally with `pnpm build:backend` and verify Python.framework is signed
- [ ] Run the app and test Chrome extension "Save This Page" feature
- [ ] Verify no "damaged" errors on clean macOS install