### PR TITLE
fix(app): prevent new chat button from reloading previous conversation

### DIFF
--- a/.changeset/fix-new-chat-button.md
+++ b/.changeset/fix-new-chat-button.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+Fix "New Chat" button immediately reloading previous conversation

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -4,15 +4,19 @@ import { useConversations } from "@/hooks/useConversations";
 import { useConversation } from "@/contexts/ConversationContext";
 import { cn } from "@/lib/utils";
 
-export function ChatSidebar() {
+interface ChatSidebarProps {
+  onNewChat: () => void;
+}
+
+export function ChatSidebar({ onNewChat }: ChatSidebarProps) {
   const { conversations, deleteConversation } = useConversations();
-  const { currentConversationId, selectConversation, startNewChat } = useConversation();
+  const { currentConversationId, selectConversation } = useConversation();
 
   const handleDelete = async (e: React.MouseEvent, id: number) => {
     e.stopPropagation();
     const success = await deleteConversation(id);
     if (success && currentConversationId === id) {
-      startNewChat();
+      onNewChat();
     }
   };
 
@@ -23,7 +27,7 @@ export function ChatSidebar() {
         <Button
           variant="outline"
           size="sm"
-          onClick={startNewChat}
+          onClick={onNewChat}
           className="w-full gap-2"
         >
           <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Fixed "New Chat" button immediately reloading the previous conversation
- Added a ref to track explicit new chat intent and guard the auto-load effect
- The auto-load effect now distinguishes between fresh page mount and user clicking "New Chat"

## Test plan
- [ ] Click "New Chat" button in chat sidebar
- [ ] Verify the chat clears and stays empty (does not reload previous conversation)
- [ ] Send a message to start a new conversation
- [ ] Verify the conversation is created correctly