### PR TITLE
fix(app): show reembed dialog when embedding model changes

### DIFF
--- a/.changeset/fix-reembed-dialog.md
+++ b/.changeset/fix-reembed-dialog.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+fix(app): show reembed dialog when embedding model changes regardless of affected count

--- a/app/src/pages/SettingsPage.tsx
+++ b/app/src/pages/SettingsPage.tsx
@@ -267,9 +267,9 @@ export default function SettingsPage({ onNameChange }: SettingsPageProps) {
 
     // Check if provider or embedding model is changing
     if (providerChanged || embeddingModelChanged) {
-      // Check embedding impact
+      // Check embedding impact - show dialog regardless of count
       const impact = await checkEmbeddingImpact();
-      if (impact && impact.affected_count > 0) {
+      if (impact) {
         setAffectedCount(impact.affected_count);
         setShowProviderWarning(true);
         return;
@@ -582,16 +582,22 @@ export default function SettingsPage({ onNameChange }: SettingsPageProps) {
                     <p className="text-sm text-muted-foreground mt-1">
                       Your changes will affect how memories are embedded for search.
                     </p>
-                    <p className="text-sm text-muted-foreground mt-2">
-                      {affectedCount} {affectedCount === 1 ? "memory" : "memories"} will need to be
-                      re-embedded for search to work correctly.
-                    </p>
+                    {affectedCount > 0 ? (
+                      <p className="text-sm text-muted-foreground mt-2">
+                        {affectedCount} {affectedCount === 1 ? "memory" : "memories"} will need to be
+                        re-embedded for search to work correctly.
+                      </p>
+                    ) : (
+                      <p className="text-sm text-muted-foreground mt-2">
+                        Your embedding model setting will be updated.
+                      </p>
+                    )}
                   </div>
                 </div>
 
                 <div className="flex flex-col gap-2">
                   <Button onClick={handleProviderSaveAndReembed} className="w-full">
-                    Save & Re-embed Now
+                    {affectedCount > 0 ? "Save & Re-embed Now" : "Save Settings"}
                   </Button>
                   <Button
                     variant="ghost"


### PR DESCRIPTION
## Summary
- Fixed reembed dialog not appearing when changing embedding model
- The dialog now shows regardless of affected memory count
- Updated dialog messaging and button text to handle count=0 case

## Root Cause
The dialog only appeared when `affected_count > 0`, but this count only includes memories that already have embeddings. Users with memories that had no embeddings (due to failed generation or async processing) would never see the dialog.

## Changes
- `SettingsPage.tsx`: Removed the `affected_count > 0` condition
- Added conditional messaging: shows re-embed count when > 0, or "setting will be updated" when 0
- Button text changes based on whether there are memories to re-embed

## Test plan
- [ ] Change embedding model when you have memories with embeddings - verify dialog shows count
- [ ] Change embedding model when you have memories without embeddings - verify dialog still appears with appropriate message
- [ ] Verify both "Save & Re-embed Now" and "Save Settings" button text appears correctly