### PR TITLE
fix(app): use mxbai-embed-large in SetupWizard

### DIFF
--- a/.changeset/fix-setup-wizard-embedding-model.md
+++ b/.changeset/fix-setup-wizard-embedding-model.md
@@ -1,0 +1,9 @@
+---
+"think-app": patch
+---
+
+fix(app): use mxbai-embed-large instead of nomic-embed-text in SetupWizard
+
+The SetupWizard was still hardcoded to download nomic-embed-text, which is now
+blocked due to crashes on content >5000 chars. Updated to use mxbai-embed-large
+to match the backend's default embedding model.

--- a/app/src/SetupWizard.tsx
+++ b/app/src/SetupWizard.tsx
@@ -112,13 +112,13 @@ export default function SetupWizard({ onComplete }: Props) {
       if (res.ok) {
         const data = await res.json();
         const models = data.models?.map((m: { name: string }) => m.name) || [];
-        const hasEmbedding = models.some((n: string) => n.startsWith('nomic-embed-text'));
+        const hasEmbedding = models.some((n: string) => n.startsWith('mxbai-embed-large'));
 
         if (!hasEmbedding && window.electronAPI) {
           setStep('pulling');
           setProgress(0);
           setStatusText('Downloading embedding model...');
-          const result = await window.electronAPI.pullModel('nomic-embed-text');
+          const result = await window.electronAPI.pullModel('mxbai-embed-large');
           if (!result.success) {
             setError(result.error || 'Embedding model download failed');
             setStep('choose');
@@ -171,7 +171,7 @@ export default function SetupWizard({ onComplete }: Props) {
     setProgress(0);
     setStatusText('Downloading embedding model...');
 
-    const embedResult = await window.electronAPI.pullModel('nomic-embed-text');
+    const embedResult = await window.electronAPI.pullModel('mxbai-embed-large');
 
     if (!embedResult.success) {
       setError(embedResult.error || 'Embedding model download failed');


### PR DESCRIPTION
## Summary
- Updated SetupWizard to use `mxbai-embed-large` instead of `nomic-embed-text`
- `nomic-embed-text` is now blocked (crashes with EOF on content >5000 chars)
- Aligns wizard with backend's default embedding model configuration

## Test plan
- [ ] Fresh install: Verify wizard downloads `mxbai-embed-large`
- [ ] Existing Ollama: Verify wizard checks for correct model and pulls if missing