### PR TITLE
fix(backend): correct API route order for stale-embeddings-count

### DIFF
--- a/.changeset/fix-stale-embeddings-route.md
+++ b/.changeset/fix-stale-embeddings-route.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+fix(backend): correct API route order for stale-embeddings-count endpoint

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -126,6 +126,14 @@ async def search_memories_semantic(
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
 
+@router.get("/memories/stale-embeddings-count")
+async def get_stale_embeddings_count():
+    """Get count of memories that need re-embedding."""
+    embedding_model = get_current_embedding_model()
+    count = await count_memories_needing_reembedding(embedding_model)
+    return {"count": count}
+
+
 @router.get("/memories/{memory_id}")
 async def read_memory(memory_id: int):
     memory = await get_memory(memory_id)
@@ -255,14 +263,6 @@ async def generate_embeddings():
             failed += 1
 
     return {"processed": processed, "failed": failed, "total": len(memories)}
-
-
-@router.get("/memories/stale-embeddings-count")
-async def get_stale_embeddings_count():
-    """Get count of memories that need re-embedding."""
-    embedding_model = get_current_embedding_model()
-    count = await count_memories_needing_reembedding(embedding_model)
-    return {"count": count}
 
 
 @router.post("/memories/regenerate-embeddings")


### PR DESCRIPTION
## Summary
- Fixed 422 error when calling `/api/memories/stale-embeddings-count`
- Moved the static route before the dynamic `{memory_id}` route so FastAPI matches it correctly

## Root Cause
FastAPI matches routes in definition order. The dynamic route `/memories/{memory_id}` was catching `/memories/stale-embeddings-count` and trying to parse the string as an integer.

## Test plan
- [ ] Verify `/api/memories/stale-embeddings-count` returns a valid count response
- [ ] Verify `/api/memories/{id}` still works for fetching individual memories