### PR TITLE
chore(backend): replace pysqlcipher3 with rotki-pysqlcipher3

### DIFF
--- a/.changeset/replace-pysqlcipher3.md
+++ b/.changeset/replace-pysqlcipher3.md
@@ -1,0 +1,10 @@
+---
+"think-app": patch
+---
+
+Replace unmaintained pysqlcipher3 with rotki-pysqlcipher3
+
+- `pysqlcipher3` is no longer maintained (last updated 2021)
+- `rotki-pysqlcipher3` is actively maintained with cross-platform wheels
+- Drop-in replacement using the same `pysqlcipher3` import namespace
+- Python version locked to 3.12.x (rotki-pysqlcipher3 wheels only support 3.11-3.12)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12,<3.14"
+python = "^3.12,<3.13"
 fastapi = "^0.115.0"
 uvicorn = "^0.32.0"
 openai = "^1.54.0"
@@ -14,7 +14,7 @@ pydantic = "^2.9.0"
 pydantic-settings = "^2.6.0"
 httpx = "^0.27.0"
 aiosqlite = "^0.20.0"
-pysqlcipher3 = "^1.2.0"
+rotki-pysqlcipher3 = "^2024.10.1"
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.0"}
 sqlite-vec = "^0.1.0"
 numpy = "^2.0.0"


### PR DESCRIPTION
## Summary
- Replace unmaintained `pysqlcipher3` with `rotki-pysqlcipher3`
- Lock Python version to `^3.12,<3.13` for wheel compatibility

## Why
- `pysqlcipher3` is no longer maintained (last updated 2021)
- `rotki-pysqlcipher3` is actively maintained with cross-platform wheels
- Drop-in replacement using the same `pysqlcipher3` import namespace

Closes #40