### PR TITLE
feat(app): improve Add to Chat to attach memory as context

### DIFF
--- a/.changeset/add-to-chat-memory-context.md
+++ b/.changeset/add-to-chat-memory-context.md
@@ -1,0 +1,11 @@
+---
+"think-app": patch
+---
+
+Improve "Add to Chat" to attach memory as context instead of prepopulating message
+
+- Add AttachedMemoryChips component showing selected memory as removable chip
+- Navigate to /chat instead of / when clicking "Add to Chat"
+- Send attached_memory_ids to backend for explicit context inclusion
+- Label attached memory as "User's Selected Memory" so AI knows which memory user is referring to
+- Preserve attached sources when special handlers run

--- a/app/src/components/AttachedMemoryChips.tsx
+++ b/app/src/components/AttachedMemoryChips.tsx
@@ -1,0 +1,47 @@
+import { X, Globe, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { chips } from "@/lib/design-tokens";
+import type { AttachedMemory } from "@/types/chat";
+
+interface AttachedMemoryChipsProps {
+  memories: AttachedMemory[];
+  onRemove: (memoryId: number) => void;
+  className?: string;
+}
+
+export function AttachedMemoryChips({
+  memories,
+  onRemove,
+  className,
+}: AttachedMemoryChipsProps) {
+  if (memories.length === 0) return null;
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {memories.map((memory) => (
+        <span
+          key={memory.id}
+          className={cn(
+            chips.base,
+            chips.primary,
+            "inline-flex items-center gap-1.5 pl-2.5 pr-1.5"
+          )}
+        >
+          {memory.type === "web" ? (
+            <Globe className="h-3 w-3 shrink-0" />
+          ) : (
+            <FileText className="h-3 w-3 shrink-0" />
+          )}
+          <span className="max-w-[150px] truncate">{memory.title}</span>
+          <button
+            onClick={() => onRemove(memory.id)}
+            className="hover:bg-primary/20 rounded-full p-0.5 transition-colors"
+            title="Remove from context"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/MemoryDetailPanel.tsx
+++ b/app/src/components/MemoryDetailPanel.tsx
@@ -82,7 +82,7 @@ export function MemoryDetailPanel({
 
   const titleInputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
-  const { startNewChat, setPendingMessage } = useConversation();
+  const { startNewChat, addAttachedMemory } = useConversation();
 
   // Listen for SSE updates to refresh memory data (e.g., after summary regeneration)
   useMemoryEvents({
@@ -227,12 +227,16 @@ export function MemoryDetailPanel({
 
   const handleAddToConversation = () => {
     if (!memory) return;
-    // Set pending message and navigate to home
-    const prompt = `Tell me about "${memory.title}"`;
-    setPendingMessage(prompt);
+    // Clear first, then attach memory (order matters - startNewChat clears attachments)
     startNewChat();
+    addAttachedMemory({
+      id: memory.id,
+      title: memory.title,
+      type: memory.type,
+      url: memory.url || undefined,
+    });
     onClose();
-    navigate("/");
+    navigate("/chat");
   };
 
   const handleRemoveTag = async (tagId: number) => {

--- a/app/src/types/chat.ts
+++ b/app/src/types/chat.ts
@@ -6,6 +6,13 @@ export interface SourceMemory {
   url?: string;
 }
 
+export interface AttachedMemory {
+  id: number;
+  title: string;
+  type: "web" | "note";
+  url?: string;
+}
+
 export interface TokenUsage {
   prompt_tokens: number;
   completion_tokens: number;

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -41,6 +41,7 @@ class ChatRequest(BaseModel):
     message: str
     conversation_id: int | None = None
     mode: str = "quick"
+    attached_memory_ids: list[int] | None = None
 
 
 # Conversation schemas


### PR DESCRIPTION
## Summary

Improves the "Add to Chat" feature to attach the memory as explicit context instead of prepopulating a message like "Tell me about X".

**Changes:**
- Show selected memory as a removable chip above the chat input
- Navigate directly to `/chat` instead of home page
- Send `attached_memory_ids` to backend for guaranteed context inclusion
- Label context as "User's Selected Memory" so AI knows which memory the user is referring to
- Combine attached memory with RAG results under "Related Context" section
- Fix: Preserve attached sources when special handlers (like "summarize recent") run

## Test plan

- [ ] Click "Add to Chat" on a memory → should navigate to chat with chip visible
- [ ] Type a message like "Tell me more about this" → AI should reference the attached memory
- [ ] Click X on chip → should remove the attachment
- [ ] Send message → chip should disappear, memory should appear in sources

Closes #50