### PR TITLE
fix(extension): prevent host page from capturing keyboard input

### DIFF
--- a/.changeset/fix-claude-keyboard-capture.md
+++ b/.changeset/fix-claude-keyboard-capture.md
@@ -1,0 +1,10 @@
+---
+"think-extension": patch
+---
+
+Fix keyboard input being captured by host page when using extension on Claude.ai
+
+- Add delegatesFocus option to Shadow DOM for better focus handling
+- Stop focus events (focusin/focusout) from propagating to host document
+- Stop keyboard events (keydown/keyup/keypress) from propagating to host document
+- Prevents sites like Claude.ai from intercepting keystrokes intended for the extension

--- a/extension/src/content.tsx
+++ b/extension/src/content.tsx
@@ -141,7 +141,17 @@ function init() {
     document.head.appendChild(fontStyleEl);
   }
 
-  const shadow = container.attachShadow({ mode: 'open' });
+  const shadow = container.attachShadow({ mode: 'open', delegatesFocus: true });
+
+  // Stop focus events from propagating to host document
+  shadow.addEventListener('focusin', (e) => e.stopPropagation());
+  shadow.addEventListener('focusout', (e) => e.stopPropagation());
+
+  // Stop keyboard events from being captured by host page (e.g., Claude.ai)
+  // Claude.ai uses global keyboard listeners that intercept keystrokes
+  shadow.addEventListener('keydown', (e) => e.stopPropagation());
+  shadow.addEventListener('keyup', (e) => e.stopPropagation());
+  shadow.addEventListener('keypress', (e) => e.stopPropagation());
 
   // Inject @font-face + Tailwind CSS into Shadow DOM
   // Fonts must be in Shadow DOM to work reliably across browsers


### PR DESCRIPTION
## Summary

Fixes keyboard input being captured by host pages (like Claude.ai) when using the Think extension.

**Problem:** When using the extension on Claude.ai, the cursor would appear in the Think input field, but keystrokes would go to Claude's chat input instead. This was because Claude.ai uses global keyboard event listeners that intercept keystrokes.

**Solution:** Add event isolation to the Shadow DOM to prevent focus and keyboard events from propagating to the host document.

## Changes

- Add `delegatesFocus: true` option to Shadow DOM for better focus handling
- Stop focus events (`focusin`/`focusout`) from propagating to host document  
- Stop keyboard events (`keydown`/`keyup`/`keypress`) from propagating to host document

## Test plan

- [x] Build extension successfully
- [ ] Load extension in browser
- [ ] Open Claude.ai and start a chat
- [ ] Open Think extension sidebar
- [ ] Verify typing in Think input works correctly (keystrokes go to Think, not Claude)

Fixes #47