### PR TITLE
fix(app): handle HTTP 307 redirects in Ollama download

### DIFF
--- a/.changeset/fix-ollama-307-redirect.md
+++ b/.changeset/fix-ollama-307-redirect.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+Fix HTTP 307 redirect handling in Ollama download for Windows users

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -16,8 +16,8 @@ function downloadFile(url, destPath, onProgress) {
 
     const makeRequest = (urlString) => {
       https.get(urlString, (response) => {
-        // Handle redirects
-        if (response.statusCode === 301 || response.statusCode === 302) {
+        // Handle redirects (301, 302, 307, 308)
+        if ([301, 302, 307, 308].includes(response.statusCode)) {
           makeRequest(response.headers.location);
           return;
         }


### PR DESCRIPTION
## Summary
- Add support for HTTP 307 and 308 redirect status codes in the `downloadFile` function
- Fixes Ollama installation failing on Windows with "HTTP 307: Temporary Redirect" error

Fixes #59