### PR TITLE
feat(app): add max width to chat message bubbles

### DIFF
--- a/.changeset/chat-max-width.md
+++ b/.changeset/chat-max-width.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+Add max width constraint to chat bubbles for consistent column layout

--- a/app/src/components/ChatMessageList.tsx
+++ b/app/src/components/ChatMessageList.tsx
@@ -115,7 +115,7 @@ export function ChatMessageList({
   }
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+    <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4 max-w-2xl mx-auto w-full">
       {messages.map((message) => (
         <ChatMessage key={message.id} message={message} />
       ))}


### PR DESCRIPTION
## Summary
- Constrain chat bubbles to `max-w-2xl` (672px) to match input width
- Creates consistent column layout on wider screens

Closes #66