### PR TITLE
feat(extension): add resizable sidepanel with content push

### DIFF
--- a/.changeset/resizable-sidepanel.md
+++ b/.changeset/resizable-sidepanel.md
@@ -1,0 +1,9 @@
+---
+"think-extension": patch
+---
+
+Add resizable sidepanel that pushes page content aside
+
+- Add draggable resize handle on left edge of panel (300px - 600px range)
+- Push webpage content aside when panel opens instead of overlaying
+- Persist panel width preference using chrome.storage

--- a/extension/src/content.css
+++ b/extension/src/content.css
@@ -68,7 +68,7 @@
   position: fixed !important;
   top: 0 !important;
   right: 0 !important;
-  width: 350px !important;
+  /* width is now set via inline style for resizing */
   height: 100vh !important;
   z-index: 2147483647 !important;
   box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
@@ -83,6 +83,33 @@
 
 #think-sidebar-wrapper.hidden {
   display: none !important;
+}
+
+/* Resize handle */
+.resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 6px;
+  height: 100%;
+  cursor: ew-resize;
+  background: transparent;
+  z-index: 10;
+  transition: background-color 0.2s ease;
+}
+
+.resize-handle:hover {
+  background: hsl(var(--primary) / 0.3);
+}
+
+.resize-handle:active {
+  background: hsl(var(--primary) / 0.5);
+}
+
+/* Prevent text selection during drag */
+#think-sidebar-wrapper.is-dragging,
+#think-sidebar-wrapper.is-dragging * {
+  user-select: none !important;
 }
 
 /* Hide scrollbar but keep scroll functionality */


### PR DESCRIPTION
## Summary

Add resizable sidepanel that pushes page content aside instead of overlaying it.

- Draggable resize handle on left edge of panel (300px - 600px range)
- Webpage content pushes aside when panel opens
- Width preference persists using chrome.storage

## Issue

Closes #72

## Test Plan

- [ ] Load extension and open sidepanel on any webpage
- [ ] Verify page content pushes aside (not overlaid)
- [ ] Hover over left edge to see resize handle highlight
- [ ] Drag to resize between 300px and 600px
- [ ] Close and reopen panel - width should persist
- [ ] Test on various sites (Gmail, Twitter, GitHub)