### PR TITLE
fix(app): conversation not appearing in sidebar when starting from home

### DIFF
--- a/.changeset/fix-conversation-sidebar-not-updating.md
+++ b/.changeset/fix-conversation-sidebar-not-updating.md
@@ -1,0 +1,8 @@
+---
+"think-app": patch
+---
+
+Fix conversation not appearing in sidebar when starting from home
+
+- Use refs for event callbacks to prevent SSE reconnection
+- Ensures conversation_created events are properly received


### PR DESCRIPTION
## Summary
- Fix bug where conversation doesn't appear in sidebar when starting from home

## Changes
- Use refs for event callbacks in useMemoryEvents hook to prevent SSE reconnection
- This ensures conversation_created events are properly received when callbacks update

Fixes #49