### PR TITLE
feat(app): add auto-updater for GitHub releases

### DIFF
--- a/.changeset/add-auto-updater.md
+++ b/.changeset/add-auto-updater.md
@@ -1,0 +1,10 @@
+---
+"think-app": patch
+---
+
+Add auto-updater for GitHub releases
+
+- Integrate electron-updater with GitHub releases provider
+- Add app menu with "Check for Updates..." option
+- Show in-app toast notification when update is ready
+- Add "Restart" action to apply downloaded updates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,11 +135,14 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
         run: pnpm build:all:release
 
-      - name: Upload DMG artifact
+      - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
         with:
           name: electron-app-macos
-          path: app/release/*.dmg
+          path: |
+            app/release/*.dmg
+            app/release/*.zip
+            app/release/latest-mac.yml
           retention-days: 1
 
   build-windows:
@@ -216,11 +219,13 @@ jobs:
       - name: Build Electron app (NSIS installer)
         run: pnpm --filter think-app electron:build
 
-      - name: Upload Windows artifact
+      - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
           name: electron-app-windows
-          path: app/release/*.exe
+          path: |
+            app/release/*.exe
+            app/release/latest.yml
           retention-days: 1
 
   upload-release:
@@ -244,7 +249,10 @@ jobs:
           files: |
             artifacts/chrome-extension/*.zip
             artifacts/electron-app-macos/*.dmg
+            artifacts/electron-app-macos/*.zip
+            artifacts/electron-app-macos/latest-mac.yml
             artifacts/electron-app-windows/*.exe
+            artifacts/electron-app-windows/latest.yml
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/electron/preload.js
+++ b/app/electron/preload.js
@@ -38,4 +38,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   // Get the app token for API authentication
   getAppToken: () => appToken,
+  // Auto-update handlers
+  onUpdateDownloaded: (callback) => {
+    ipcRenderer.on('update-downloaded', (_, version) => callback(version));
+  },
+  removeUpdateListeners: () => {
+    ipcRenderer.removeAllListeners('update-downloaded');
+  },
+  installUpdate: () => ipcRenderer.invoke('install-update'),
 });

--- a/app/package.json
+++ b/app/package.json
@@ -37,7 +37,7 @@
     ],
     "mac": {
       "icon": "build/icon.icns",
-      "target": "dmg",
+      "target": ["dmg", "zip"],
       "category": "public.app-category.productivity",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
@@ -55,6 +55,11 @@
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
       "shortcutName": "Think"
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "ThinkFoundation",
+      "repo": "ThinkOS-Client"
     }
   },
   "dependencies": {
@@ -65,6 +70,7 @@
     "@tiptap/starter-kit": "^3.13.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-updater": "^6.6.2",
     "lucide-react": "^0.460.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import SettingsPage from "./pages/SettingsPage";
 import { NamePromptDialog } from "./components/NamePromptDialog";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
+import { toast } from "sonner";
 import { useSystemTheme } from "@/hooks/useSystemTheme";
 import { initializeApiToken, apiFetch } from "@/lib/api";
 
@@ -182,6 +183,26 @@ function App() {
       checkNamePrompt();
     }
   }, [appState]);
+
+  // Listen for app updates
+  useEffect(() => {
+    if (window.electronAPI?.onUpdateDownloaded) {
+      window.electronAPI.onUpdateDownloaded((version: string) => {
+        toast("Update Ready", {
+          description: `Version ${version} is ready to install.`,
+          action: {
+            label: "Restart",
+            onClick: () => window.electronAPI?.installUpdate(),
+          },
+          duration: Infinity,
+        });
+      });
+
+      return () => {
+        window.electronAPI?.removeUpdateListeners();
+      };
+    }
+  }, []);
 
   if (appState === "waiting_for_backend") {
     return (

--- a/app/src/SetupWizard.tsx
+++ b/app/src/SetupWizard.tsx
@@ -25,6 +25,10 @@ declare global {
       removeBackendListeners: () => void;
       // App token for API authentication
       getAppToken: () => string | null;
+      // Auto-update handlers
+      onUpdateDownloaded: (callback: (version: string) => void) => void;
+      removeUpdateListeners: () => void;
+      installUpdate: () => Promise<void>;
     };
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@18.3.1)
@@ -1301,6 +1304,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.3.1:
+    resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -1650,6 +1657,9 @@ packages:
 
   electron-to-chromium@1.5.259:
     resolution: {integrity: sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==}
+
+  electron-updater@6.6.2:
+    resolution: {integrity: sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==}
 
   electron@33.4.11:
     resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
@@ -2247,8 +2257,15 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -3236,6 +3253,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -4810,6 +4830,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.3.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -5216,6 +5243,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.259: {}
+
+  electron-updater@6.6.2:
+    dependencies:
+      builder-util-runtime: 9.3.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.3
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron@33.4.11:
     dependencies:
@@ -5857,7 +5897,11 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -7049,6 +7093,8 @@ snapshots:
       any-promise: 1.3.0
 
   through@2.3.8: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinyexec@1.0.2: {}
 


### PR DESCRIPTION
## Summary
- Integrate electron-updater with GitHub releases provider
- Add app menu with "Check for Updates..." option  
- Show in-app toast notification when update is ready with "Restart" action
- Update release workflow to upload .zip and latest.yml manifests for auto-update

Closes #78

## Test plan
- [ ] Verify app builds successfully with new electron-updater dependency
- [ ] Test "Check for Updates..." menu item appears (macOS: Think menu, Windows: Help menu)
- [ ] Verify release workflow uploads .zip and latest-mac.yml for macOS
- [ ] Verify release workflow uploads latest.yml for Windows
- [ ] Test update flow with a published release (requires version bump and release)