### PR TITLE
fix(app): replace fullscreen icon with panel icon in memory overview

### DIFF
--- a/.changeset/fix-memory-card-icon.md
+++ b/.changeset/fix-memory-card-icon.md
@@ -1,0 +1,7 @@
+---
+"think-app": patch
+---
+
+fix: replace fullscreen icon with panel icon in memory overview
+
+Replace the misleading Maximize2 (fullscreen) icon with a PanelRight icon on memory cards. The button opens a detail sidebar panel, and the new icon accurately represents this behavior.

--- a/app/src/components/MemoryCard.tsx
+++ b/app/src/components/MemoryCard.tsx
@@ -5,7 +5,7 @@ import {
   Trash2,
   X,
   Link as LinkIcon,
-  Maximize2,
+  PanelRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -99,7 +99,7 @@ export function MemoryCard({
           className="h-7 w-7 text-muted-foreground hover:text-foreground"
           title="View Details"
         >
-          <Maximize2 className="h-3.5 w-3.5" />
+          <PanelRight className="h-3.5 w-3.5" />
         </Button>
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary

- Replace misleading `Maximize2` (fullscreen) icon with `PanelRight` icon on memory cards
- The button opens a detail sidebar panel, and the new icon accurately represents this behavior

Closes #83

## Test plan

- [ ] Hover over a memory card in the Memories page
- [ ] Verify the icon appears as a panel/sidebar icon instead of the expand arrows
- [ ] Verify clicking still opens the detail panel correctly