### PR TITLE
fix(app): require confirmation for memory deletion

### DIFF
--- a/.changeset/memory-delete-confirmation.md
+++ b/.changeset/memory-delete-confirmation.md
@@ -1,0 +1,8 @@
+---
+"think-app": patch
+---
+
+fix: require confirmation for memory deletion
+
+Remove delete button from memory card hover menu. Users must now open the
+detail sidebar panel to delete a memory, which has a confirmation dialog.

--- a/app/src/components/MemoryCard.tsx
+++ b/app/src/components/MemoryCard.tsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import {
   Globe,
   FileText,
-  Trash2,
   X,
   Link as LinkIcon,
   PanelRight,
@@ -27,7 +26,6 @@ interface Memory {
 
 interface MemoryCardProps {
   memory: Memory;
-  onDelete: (id: number) => void;
   onRemoveTag: (memoryId: number, tagId: number) => void;
   onExpand: (id: number) => void;
   formatDate: (date: string) => string;
@@ -65,7 +63,6 @@ function DomainBadge({ url }: { url: string }) {
 
 export function MemoryCard({
   memory,
-  onDelete,
   onRemoveTag,
   onExpand,
   formatDate,
@@ -100,15 +97,6 @@ export function MemoryCard({
           title="View Details"
         >
           <PanelRight className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onDelete(memory.id)}
-          className="h-7 w-7 text-muted-foreground hover:text-destructive"
-          title="Delete"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
         </Button>
       </div>
 

--- a/app/src/pages/MemoriesPage.tsx
+++ b/app/src/pages/MemoriesPage.tsx
@@ -530,7 +530,6 @@ export default function MemoriesPage() {
             <div key={memory.id} className="break-inside-avoid mb-4">
               <MemoryCard
                 memory={memory}
-                onDelete={handleDelete}
                 onRemoveTag={handleRemoveTag}
                 onExpand={handleExpand}
                 formatDate={formatDate}


### PR DESCRIPTION
## Summary

- Remove delete button from memory card hover menu
- Users must now open the detail sidebar panel to delete a memory
- The sidebar already has a confirmation dialog, preventing accidental deletion

Closes #81

## Test plan

- [ ] Hover over a memory card - only the panel icon should appear (no trash icon)
- [ ] Click panel icon to open sidebar
- [ ] Verify delete button exists in sidebar footer
- [ ] Click delete and verify confirmation dialog appears
- [ ] Confirm deletion works correctly