### PR TITLE
feat(app): add edit button for notes in memory card

### DIFF
--- a/.changeset/note-edit-button.md
+++ b/.changeset/note-edit-button.md
@@ -1,0 +1,8 @@
+---
+"think-app": minor
+---
+
+feat: add edit button for notes in memory card
+
+Add a pencil icon button on note memory cards that opens the editor
+directly, without having to go through the detail panel first.

--- a/app/src/components/MemoryCard.tsx
+++ b/app/src/components/MemoryCard.tsx
@@ -5,6 +5,7 @@ import {
   X,
   Link as LinkIcon,
   PanelRight,
+  Pencil,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -28,6 +29,7 @@ interface MemoryCardProps {
   memory: Memory;
   onRemoveTag: (memoryId: number, tagId: number) => void;
   onExpand: (id: number) => void;
+  onEdit?: (id: number) => void;
   formatDate: (date: string) => string;
 }
 
@@ -65,6 +67,7 @@ export function MemoryCard({
   memory,
   onRemoveTag,
   onExpand,
+  onEdit,
   formatDate,
 }: MemoryCardProps) {
   return (
@@ -89,6 +92,17 @@ export function MemoryCard({
           "transition-opacity duration-200"
         )}
       >
+        {memory.type === "note" && onEdit && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onEdit(memory.id)}
+            className="h-7 w-7 text-muted-foreground hover:text-foreground"
+            title="Edit Note"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/app/src/pages/MemoriesPage.tsx
+++ b/app/src/pages/MemoriesPage.tsx
@@ -292,6 +292,14 @@ export default function MemoriesPage() {
     setIsPanelOpen(true);
   };
 
+  // Open note editor directly from card
+  const handleEdit = (id: number) => {
+    const memory = memories.find((m) => m.id === id);
+    if (memory) {
+      openNoteEditor(memory);
+    }
+  };
+
   // Close detail panel
   const closePanel = () => {
     setIsPanelOpen(false);
@@ -532,6 +540,7 @@ export default function MemoriesPage() {
                 memory={memory}
                 onRemoveTag={handleRemoveTag}
                 onExpand={handleExpand}
+                onEdit={handleEdit}
                 formatDate={formatDate}
               />
             </div>


### PR DESCRIPTION
## Summary

- Add pencil icon button on note memory cards
- Opens the NoteEditor directly from the card (bypasses detail panel)
- Only appears for "note" type memories (not web memories)

Closes #82

## Test plan

- [ ] Hover over a **note** memory card - should see pencil + panel icons
- [ ] Hover over a **web** memory card - should only see panel icon (no pencil)
- [ ] Click pencil icon on note - should open NoteEditor directly
- [ ] Verify existing flow (panel → edit) still works