### PR TITLE
feat(app): add dashboard quick actions and view all for chats

### DIFF
--- a/.changeset/dashboard-quick-actions.md
+++ b/.changeset/dashboard-quick-actions.md
@@ -1,0 +1,10 @@
+---
+"think-app": patch
+---
+
+Add "View all" and "New Conversation" quick actions to dashboard
+
+- Added "View all" button to Recent Chats card linking to /chat
+- Renamed "Quick Add" to "Quick Actions" with centered button layout
+- Added "New Conversation" quick action that starts a fresh chat
+- Fixed navigation to ensure new conversations don't auto-load previous chat

--- a/app/src/pages/ChatPage.tsx
+++ b/app/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { apiFetch } from "@/lib/api";
 import { ChatInput } from "@/components/ChatInput";
 import { ChatMessageList } from "@/components/ChatMessageList";
@@ -19,6 +20,7 @@ export default function ChatPage() {
   const [followupSuggestions, setFollowupSuggestions] = useState<string[]>([]);
   const isStartingNewChatRef = useRef(false);
   const wantsNewChatRef = useRef(false);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // Track pending conversation creation to prevent race conditions
   const pendingConversationRef = useRef<{
@@ -256,6 +258,16 @@ export default function ChatPage() {
   const handleChat = useCallback(() => {
     submitChat(message, currentConversationId);
   }, [message, currentConversationId, submitChat]);
+
+  // Effect: Handle ?new=true param from navigation (e.g., from HomePage "New Conversation")
+  useEffect(() => {
+    if (searchParams.get("new") === "true") {
+      wantsNewChatRef.current = true;
+      startNewChat();
+      searchParams.delete("new");
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, startNewChat]);
 
   // Effect 1: Handle pending message from navigation (e.g., from HomePage)
   useEffect(() => {

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -152,7 +152,7 @@ export default function HomePage({ userName }: HomePageProps) {
               {recentChats.length === 0 ? (
                 <p className="text-sm text-muted-foreground">No chats yet</p>
               ) : (
-                <ul className="space-y-2">
+                <ul className="space-y-1">
                   {recentChats.map((chat) => (
                     <li
                       key={chat.id}
@@ -160,33 +160,45 @@ export default function HomePage({ userName }: HomePageProps) {
                         selectConversation(chat);
                         navigate("/chat");
                       }}
-                      className="text-sm truncate text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+                      className="text-sm truncate text-muted-foreground hover:text-foreground cursor-pointer transition-colors py-1 -mx-2 px-2 rounded hover:bg-muted"
                     >
                       {chat.title || "New conversation"}
                     </li>
                   ))}
                 </ul>
               )}
+              <Link to="/chat">
+                <Button variant="ghost" size="sm" className="mt-2 w-full">
+                  View all
+                </Button>
+              </Link>
             </CardContent>
           </Card>
 
-          {/* Quick Add */}
+          {/* Quick Actions */}
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium flex items-center gap-2">
                 <Plus className="h-4 w-4" />
-                Quick Add
+                Quick Actions
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground mb-3">
-                Save a new memory manually
-              </p>
-              <Link to="/memories?add=true">
+            <CardContent className="flex flex-col items-center justify-center space-y-3 py-4">
+              <Link to="/memories?add=true" className="w-full">
                 <Button variant="outline" size="sm" className="w-full">
-                  Add Note
+                  New Note
                 </Button>
               </Link>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => {
+                  navigate("/chat?new=true");
+                }}
+              >
+                New Conversation
+              </Button>
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
- Add "View all" button to Recent Chats card on dashboard
- Rename "Quick Add" to "Quick Actions" with centered layout
- Add "New Conversation" quick action button
- Fix new conversation to start fresh using `?new=true` param

## Test plan
- [ ] Verify "View all" on Recent Chats navigates to /chat and loads most recent conversation
- [ ] Verify "New Conversation" navigates to /chat with a blank slate
- [ ] Verify Quick Actions card layout is centered with proper spacing

Closes #