### PR TITLE
fix(app): remove hover scale that caused blurry text

### DIFF
--- a/.changeset/smooth-cards-hover.md
+++ b/.changeset/smooth-cards-hover.md
@@ -1,0 +1,5 @@
+---
+"think-app": patch
+---
+
+Remove scale transform on memory card hover that caused text to appear blurry

--- a/app/src/components/MemoryCard.tsx
+++ b/app/src/components/MemoryCard.tsx
@@ -80,7 +80,7 @@ export function MemoryCard({
         "shadow-sm shadow-black/5 dark:shadow-black/20",
         // Hover lift effect
         "hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30",
-        "hover:scale-[1.01] hover:-translate-y-0.5",
+        "hover:-translate-y-0.5",
         "transition-all duration-200"
       )}
     >


### PR DESCRIPTION
## Summary
- Remove `hover:scale-[1.01]` from memory card hover effect that caused text to appear blurry due to sub-pixel rendering

## Test plan
- [ ] Navigate to Memories page
- [ ] Hover over memory cards
- [ ] Verify text remains crisp (no blur)
- [ ] Verify hover effect still feels responsive (shadow + lift)

Fixes #97