### PR TITLE
feat(app): add skill system

### DIFF
--- a/.changeset/skill-system-phase1.md
+++ b/.changeset/skill-system-phase1.md
@@ -1,0 +1,25 @@
+---
+"think-app": minor
+---
+
+Add skill system with built-in skills, editor, triggers, and chat integration
+
+- Add skills, skill_executions, and skill_triggers database tables
+- Add 3 built-in skills: Extract Action Items, Generate Insights, Export to Markdown
+- Add skill registry with validation and built-in skill seeding
+- Add skill executor with content extraction, template rendering, and LLM streaming
+- Add full CRUD API for user-created skills (create, update, delete, toggle)
+- Add skill editor with two-column layout, emoji picker, logo upload
+- Add skill import/export via .think-skill JSON format with validation
+- Add skill test runner with live SSE streaming preview
+- Add execution history with filtering by skill, status, and search
+- Add skill detail panel with recent executions and clickable memory links
+- Add trigger engine for automatic skill execution on memory save
+- Add trigger condition builder with field/operator/value rules and AND/OR logic
+- Add trigger preview with match ratio bar and memory type indicators
+- Add chat-based skill suggestions via pattern matching on message context
+- Add ChatSkillChips and ChatSkillResult components for in-chat skill execution
+- Add SSE streaming for chat skill results with real-time token updates
+- Respect output_format field during execution (plain, json, html, markdown)
+- Hide incompatible skills from selection list
+- Integrate skill results section into MemoryDetailPanel

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Menu, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu, shell, dialog } = require('electron');
 const { autoUpdater } = require('electron-updater');
 const { spawn, execSync } = require('child_process');
 const crypto = require('crypto');
@@ -64,6 +64,9 @@ function downloadFile(url, destPath, onProgress) {
 let mainWindow;
 let pythonProcess;
 let backendReady = false;
+
+// Buffer for .think-skill file opened before window is ready
+let pendingSkillFilePath = null;
 
 // Generate a secure random token for API authentication
 // This ensures only this Electron app can access the Python backend
@@ -322,6 +325,50 @@ function createWindow() {
   }
 }
 
+// Handle .think-skill file association
+function sendSkillFileToRenderer(filePath) {
+  if (!filePath || !filePath.endsWith('.think-skill')) return;
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('import-skill-file', { filePath, content });
+    } else {
+      pendingSkillFilePath = filePath;
+    }
+  } catch (err) {
+    console.error('Failed to read .think-skill file:', err);
+  }
+}
+
+// macOS: file opened via double-click or Finder
+app.on('open-file', (event, filePath) => {
+  event.preventDefault();
+  if (app.isReady()) {
+    sendSkillFileToRenderer(filePath);
+  } else {
+    pendingSkillFilePath = filePath;
+  }
+});
+
+// Windows/Linux: request single instance lock for file association
+const gotTheLock = app.requestSingleInstanceLock();
+if (!gotTheLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    // argv may contain the .think-skill file path (last argument on Win/Linux)
+    const skillFile = argv.find(arg => arg.endsWith('.think-skill'));
+    if (skillFile) {
+      sendSkillFileToRenderer(skillFile);
+    }
+    // Focus existing window
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+}
+
 app.whenReady().then(async () => {
   // Set app name (for dev mode - production uses productName from package.json)
   app.setName('Think');
@@ -363,6 +410,12 @@ app.whenReady().then(async () => {
     // Initialize system tray after backend is ready
     const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
     createTray(mainWindow, APP_TOKEN, isDev);
+
+    // Send pending skill file if app was opened via file association
+    if (pendingSkillFilePath) {
+      sendSkillFileToRenderer(pendingSkillFilePath);
+      pendingSkillFilePath = null;
+    }
   } catch (err) {
     console.error('Backend startup failed:', err);
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -636,6 +689,27 @@ ipcMain.handle('delete-temp-file', async (_event, filePath) => {
     return { success: true };
   } catch (error) {
     console.error('[IPC] delete-temp-file error:', error);
+    return { success: false, error: error.message };
+  }
+});
+
+// Save a .think-skill file via system dialog
+ipcMain.handle('save-skill-file', async (_event, content, suggestedName) => {
+  try {
+    const result = await dialog.showSaveDialog(mainWindow, {
+      defaultPath: suggestedName,
+      filters: [
+        { name: 'ThinkOS Skill', extensions: ['think-skill'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    if (result.canceled || !result.filePath) {
+      return { success: false };
+    }
+    fs.writeFileSync(result.filePath, content, 'utf-8');
+    return { success: true, filePath: result.filePath };
+  } catch (error) {
+    console.error('[IPC] save-skill-file error:', error);
     return { success: false, error: error.message };
   }
 });

--- a/app/electron/preload.js
+++ b/app/electron/preload.js
@@ -64,4 +64,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   // Document viewing
   openDocumentWithSystem: (documentId, filename) => ipcRenderer.invoke('open-document-with-system', documentId, filename),
+  // Skill file import/export
+  onImportSkillFile: (callback) => {
+    ipcRenderer.on('import-skill-file', (_, data) => callback(data));
+  },
+  removeImportSkillFileListener: () => {
+    ipcRenderer.removeAllListeners('import-skill-file');
+  },
+  saveSkillFile: (content, suggestedName) => ipcRenderer.invoke('save-skill-file', content, suggestedName),
 });

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,14 @@
     "directories": {
       "output": "release"
     },
+    "fileAssociations": [
+      {
+        "ext": "think-skill",
+        "name": "ThinkOS Skill",
+        "mimeType": "application/x-think-skill",
+        "role": "Editor"
+      }
+    ],
     "files": [
       "dist/**/*",
       "electron/**/*"
@@ -74,6 +82,8 @@
     }
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,6 +9,8 @@ import MemoriesPage from "./pages/MemoriesPage";
 import GraphPage from "./pages/GraphPage";
 import SettingsPage from "./pages/SettingsPage";
 import RecordingPage from "./pages/RecordingPage";
+import SkillsPage from "./pages/SkillsPage";
+import SkillEditor from "./components/SkillEditor";
 import { NamePromptDialog } from "./components/NamePromptDialog";
 import { Button } from "@/components/ui/button";
 import { Lock } from "lucide-react";
@@ -188,6 +190,22 @@ function App() {
     }
   }, [appState]);
 
+  // Listen for .think-skill file imports from Electron
+  useEffect(() => {
+    if (appState !== "ready") return;
+    if (!window.electronAPI?.onImportSkillFile) return;
+
+    window.electronAPI.onImportSkillFile((data: { filePath: string; content: string }) => {
+      window.dispatchEvent(
+        new CustomEvent("import-skill-file", { detail: data })
+      );
+    });
+
+    return () => {
+      window.electronAPI?.removeImportSkillFileListener?.();
+    };
+  }, [appState]);
+
   // Listen for app updates
   useEffect(() => {
     if (window.electronAPI?.onUpdateDownloaded) {
@@ -285,6 +303,9 @@ function App() {
             <Route path="/memories" element={<MemoriesPage />} />
             <Route path="/chat" element={<ChatPage />} />
             <Route path="/graph" element={<GraphPage />} />
+            <Route path="/skills" element={<SkillsPage />} />
+            <Route path="/skills/new" element={<SkillEditor />} />
+            <Route path="/skills/:id/edit" element={<SkillEditor />} />
             <Route
               path="/settings"
               element={<SettingsPage onNameChange={setUserName} />}

--- a/app/src/components/ChatMessage.tsx
+++ b/app/src/components/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { AlertCircle } from "lucide-react";
 import { glass } from "@/lib/design-tokens";
 import type { ChatMessage as ChatMessageType } from "@/types/chat";
 import { ChatMessageActions } from "./ChatMessageActions";
+import { ChatSkillResult } from "./ChatSkillResult";
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -11,6 +12,11 @@ interface ChatMessageProps {
 
 export function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.role === "user";
+
+  // Dispatch to skill result component for skill execution messages
+  if (message.metadata?.skill_execution_id) {
+    return <ChatSkillResult message={message} />;
+  }
 
   if (message.error) {
     return (

--- a/app/src/components/ChatMessageList.tsx
+++ b/app/src/components/ChatMessageList.tsx
@@ -3,7 +3,8 @@ import { Loader2, Search } from "lucide-react";
 import { apiFetch } from "@/lib/api";
 import { ChatMessage } from "./ChatMessage";
 import { PromptChips } from "./PromptChips";
-import type { ChatMessage as ChatMessageType } from "@/types/chat";
+import { ChatSkillChips } from "./ChatSkillChips";
+import type { ChatMessage as ChatMessageType, SkillSuggestion } from "@/types/chat";
 
 // Fallback prompts in case API fails
 const FALLBACK_PROMPTS = [
@@ -22,6 +23,9 @@ interface ChatMessageListProps {
   isLoading?: boolean;
   onSendMessage?: (message: string) => void;
   followupSuggestions?: string[];
+  skillSuggestions?: SkillSuggestion[];
+  onExecuteSkill?: (suggestion: SkillSuggestion) => void;
+  isExecutingSkill?: boolean;
 }
 
 export function ChatMessageList({
@@ -29,6 +33,9 @@ export function ChatMessageList({
   isLoading,
   onSendMessage,
   followupSuggestions = [],
+  skillSuggestions = [],
+  onExecuteSkill,
+  isExecutingSkill = false,
 }: ChatMessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [quickPrompts, setQuickPrompts] = useState<string[]>(FALLBACK_PROMPTS);
@@ -130,6 +137,16 @@ export function ChatMessageList({
           </div>
         </div>
       )}
+      {!isLoading &&
+        !hasStreamingMessage &&
+        skillSuggestions.length > 0 &&
+        onExecuteSkill && (
+          <ChatSkillChips
+            suggestions={skillSuggestions}
+            onExecute={onExecuteSkill}
+            isExecuting={isExecutingSkill}
+          />
+        )}
       {showFollowups && onSendMessage && (
         <PromptChips
           prompts={followupSuggestions}

--- a/app/src/components/ChatSkillChips.tsx
+++ b/app/src/components/ChatSkillChips.tsx
@@ -1,0 +1,66 @@
+import { Zap, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { glass } from "@/lib/design-tokens";
+import type { SkillSuggestion } from "@/types/chat";
+
+interface ChatSkillChipsProps {
+  suggestions: SkillSuggestion[];
+  onExecute: (suggestion: SkillSuggestion) => void;
+  isExecuting?: boolean;
+  className?: string;
+}
+
+export function ChatSkillChips({
+  suggestions,
+  onExecute,
+  isExecuting = false,
+  className,
+}: ChatSkillChipsProps) {
+  if (!suggestions.length) return null;
+
+  return (
+    <div className={cn("animate-slide-up", className)}>
+      {/* Section header — matches SkillDetail pattern */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="h-3 w-0.5 rounded-full bg-amber-500" />
+        <Zap className="h-3 w-3 text-amber-500" />
+        <span className="text-[10px] font-semibold text-muted-foreground/60 uppercase tracking-widest">
+          Suggested Skills
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map((suggestion, index) => (
+          <button
+            key={`${suggestion.skill_id}-${suggestion.memory_id}`}
+            onClick={() => onExecute(suggestion)}
+            disabled={isExecuting}
+            className={cn(
+              "group/chip flex items-center gap-2 pl-3 pr-3.5 py-2 rounded-xl text-xs transition-all duration-200 animate-fade-in-up",
+              "border-l-2 border-l-amber-500/30",
+              glass.elevated,
+              "hover:shadow-lg hover:shadow-primary/10 hover:scale-[1.02] hover:-translate-y-0.5",
+              "disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:translate-y-0",
+              isExecuting && "animate-pulse"
+            )}
+            style={{ animationDelay: `${index * 60}ms`, animationFillMode: "both" }}
+          >
+            {isExecuting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-primary/60 flex-shrink-0" />
+            ) : (
+              <span className="text-sm leading-none flex-shrink-0">{suggestion.skill_icon}</span>
+            )}
+            <div className="flex flex-col items-start min-w-0">
+              <span className="font-medium truncate">{suggestion.skill_name}</span>
+              {suggestion.memory_title && (
+                <span className="text-[10px] text-muted-foreground/40 truncate max-w-[180px]">
+                  on &ldquo;{suggestion.memory_title}&rdquo;
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/ChatSkillResult.tsx
+++ b/app/src/components/ChatSkillResult.tsx
@@ -1,0 +1,92 @@
+import ReactMarkdown from "react-markdown";
+import { useNavigate } from "react-router-dom";
+import { Zap, CheckCircle2, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { glass } from "@/lib/design-tokens";
+import { ChatMessageActions } from "./ChatMessageActions";
+import type { ChatMessage } from "@/types/chat";
+
+interface ChatSkillResultProps {
+  message: ChatMessage;
+}
+
+export function ChatSkillResult({ message }: ChatSkillResultProps) {
+  const navigate = useNavigate();
+  const meta = message.metadata;
+  const isStreaming = !!message.isStreaming;
+  const isComplete = !isStreaming && !!message.content;
+
+  return (
+    <div className="group flex justify-start animate-slide-up">
+      <div className="relative max-w-[80%]">
+        <ChatMessageActions message={message} />
+
+        <div className={cn("rounded-2xl overflow-hidden", glass.base)}>
+          {/* Skill badge header — gradient */}
+          <div className="relative flex items-center gap-2 px-4 py-2.5 border-b border-white/20 dark:border-white/[0.04] overflow-hidden">
+            {/* Gradient background */}
+            <div className="absolute inset-0 bg-gradient-to-r from-primary/8 to-transparent" />
+
+            <div className="relative flex items-center gap-2 flex-1 min-w-0">
+              {meta?.skill_icon && (
+                <span className="text-sm leading-none flex-shrink-0">{meta.skill_icon}</span>
+              )}
+              <div className="flex flex-col min-w-0">
+                <span className="text-xs font-medium text-primary truncate">
+                  {meta?.skill_name || "Skill Result"}
+                </span>
+                {meta?.memory_title && (
+                  <span className="text-[10px] text-muted-foreground/40 truncate">
+                    on &ldquo;{meta.memory_title}&rdquo;
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Status indicator */}
+            <div className="relative flex-shrink-0">
+              {isComplete ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+              ) : (
+                <div className="flex items-center gap-1.5">
+                  <Zap className="h-3 w-3 text-amber-500" />
+                  {isStreaming && (
+                    <div className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Content */}
+          <div className="p-4">
+            <div className="chat-prose text-sm">
+              <ReactMarkdown>{message.content}</ReactMarkdown>
+              {isStreaming && (
+                <span className="inline-block w-2 h-4 ml-0.5 bg-current animate-pulse" />
+              )}
+            </div>
+          </div>
+
+          {/* Footer — proper button */}
+          {meta?.memory_id && !isStreaming && (
+            <div className="px-4 py-2.5 border-t border-white/20 dark:border-white/[0.04]">
+              <button
+                onClick={() => navigate(`/memories?open=${meta.memory_id}`)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium transition-all duration-200",
+                  "text-muted-foreground/50 hover:text-primary",
+                  glass.card,
+                  "hover:shadow-sm hover:shadow-primary/10"
+                )}
+              >
+                View in Memory Detail
+                <ArrowRight className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/MemoryDetailPanel.tsx
+++ b/app/src/components/MemoryDetailPanel.tsx
@@ -21,7 +21,6 @@ import {
   Trash2,
   Link as LinkIcon,
   Sparkles,
-  Lightbulb,
   Network,
   Play,
   Pause,
@@ -35,6 +34,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
+  Zap,
 } from "lucide-react";
 
 // Set up PDF.js worker - served from public folder (dev) or copied to dist (build)
@@ -50,6 +50,7 @@ import { API_BASE_URL } from "@/constants";
 import { useMemoryEvents } from "../hooks/useMemoryEvents";
 import { useConversation } from "../contexts/ConversationContext";
 import { LinkMemoryDialog } from "./LinkMemoryDialog";
+import { SkillRunner, SkillResultsSection } from "./SkillRunner";
 import type { TranscriptionStatus, TranscriptSegment, VideoProcessingStatus } from "@/types/chat";
 
 interface MemoryTag {
@@ -164,6 +165,10 @@ export function MemoryDetailPanel({
   const [isLoadingLinks, setIsLoadingLinks] = useState(false);
   const [showLinkDialog, setShowLinkDialog] = useState(false);
 
+  // Skill runner state
+  const [showSkillRunner, setShowSkillRunner] = useState(false);
+  const [initialExecutionId, setInitialExecutionId] = useState<number | null>(null);
+
   // Suggestions state
   const [suggestions, setSuggestions] = useState<MemorySuggestion[]>([]);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
@@ -206,6 +211,8 @@ export function MemoryDetailPanel({
     if (memoryId && isOpen) {
       fetchMemory(memoryId);
       fetchSuggestions(memoryId);
+      setShowSkillRunner(false);
+      setInitialExecutionId(null);
     }
   }, [memoryId, isOpen]);
 
@@ -1044,21 +1051,44 @@ export function MemoryDetailPanel({
           isOpen ? "translate-x-0" : "translate-x-full"
         )}
       >
-        {/* Close button */}
-        <div className="flex justify-end px-4 py-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onClose}
-            className="h-8 w-8"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+        {/* Toolbar */}
+        <div className="flex justify-between items-center px-4 py-3">
+          <div />
+          <div className="flex items-center gap-1.5">
+            {!showSkillRunner && memory && (
+              <button
+                onClick={() => setShowSkillRunner(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-xl bg-primary/5 hover:bg-primary/10 border border-primary/20 text-foreground hover:shadow-sm hover:shadow-primary/10 transition-all duration-200"
+              >
+                <Zap className="h-3.5 w-3.5 text-primary" />
+                Skills
+              </button>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-8 w-8"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
-          {isLoading ? (
+          {showSkillRunner && memory ? (
+            <SkillRunner
+              memoryId={memory.id}
+              memory={memory}
+              onClose={() => {
+                setShowSkillRunner(false);
+                setInitialExecutionId(null);
+              }}
+              formatDate={formatDate}
+              initialExecutionId={initialExecutionId}
+            />
+          ) : isLoading ? (
             <div className="p-6 space-y-4">
               <div className="animate-pulse space-y-4">
                 <div className="h-6 bg-muted rounded w-3/4" />
@@ -1801,6 +1831,16 @@ export function MemoryDetailPanel({
                 </div>
               )}
 
+              {/* Skill Results */}
+              <SkillResultsSection
+                memoryId={memory.id}
+                formatDate={formatDate}
+                onViewExecution={(executionId) => {
+                  setInitialExecutionId(executionId);
+                  setShowSkillRunner(true);
+                }}
+              />
+
               {/* Summary Section */}
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
@@ -2079,16 +2119,6 @@ export function MemoryDetailPanel({
                 )}
               </div>
 
-              {/* Future Sections (Placeholders) */}
-              <div className="space-y-3 pt-4 border-t">
-                <div className="flex items-center gap-2 text-muted-foreground/60">
-                  <Lightbulb className="h-4 w-4" />
-                  <span className="text-sm">Insights</span>
-                  <span className="text-xs bg-muted px-2 py-0.5 rounded-full ml-auto">
-                    Coming Soon
-                  </span>
-                </div>
-              </div>
             </div>
           ) : (
             <div className="p-6 text-center text-muted-foreground">

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
-import { Home, Brain, Settings, MessageSquare, Network } from "lucide-react";
+import { Home, Brain, Settings, MessageSquare, Network, Zap } from "lucide-react";
 import ProviderStatusIndicator from "./ProviderStatusIndicator";
 import { ChangelogDialog } from "./ChangelogDialog";
 import { useConversation } from "@/contexts/ConversationContext";
@@ -18,6 +18,7 @@ const navItems = [
   { to: "/memories", icon: Brain, label: "Memories" },
   { to: "/chat", icon: MessageSquare, label: "Chats" },
   { to: "/graph", icon: Network, label: "Graph" },
+  { to: "/skills", icon: Zap, label: "Skills" },
   { to: "/settings", icon: Settings, label: "Settings" },
 ];
 

--- a/app/src/components/SkillDetail.tsx
+++ b/app/src/components/SkillDetail.tsx
@@ -1,0 +1,524 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import {
+  X,
+  Pencil,
+  Download,
+  Trash2,
+  Eye,
+  EyeOff,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  Zap,
+  Plus,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { glass, chips } from "@/lib/design-tokens";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { useSkillDetail, useSkillMutations, useTriggers } from "@/hooks/useSkills";
+import { exportSkill } from "@/lib/api";
+import type { ExecutionHistoryItem, SkillTrigger, TriggerCreateRequest, TriggerUpdateRequest } from "@/lib/api";
+import TriggerList from "./TriggerList";
+import TriggerEditor from "./TriggerEditor";
+
+interface SkillDetailProps {
+  skillId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onDeleted: () => void;
+  onUpdated: () => void;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "\u2014";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return "\u2014";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ExecutionItem({ execution }: { execution: ExecutionHistoryItem }) {
+  const navigate = useNavigate();
+  return (
+    <div className="flex items-center gap-2 py-2 px-2 rounded-lg hover:bg-white/30 dark:hover:bg-white/[0.03] transition-colors text-sm">
+      <div className="flex-1 min-w-0">
+        <button
+          onClick={() => navigate(`/memories?open=${execution.memory_id}`)}
+          className="text-xs truncate block max-w-full hover:text-primary hover:underline transition-colors"
+        >
+          {execution.memory_title || "Untitled"}
+        </button>
+        <p className="text-[10px] text-muted-foreground/60 mt-0.5">
+          {formatDateTime(execution.created_at)}
+          {execution.duration_seconds != null && ` \u00b7 ${execution.duration_seconds}s`}
+        </p>
+      </div>
+      {execution.status === "completed" ? (
+        <div className={cn("h-5 w-5 rounded-full flex items-center justify-center flex-shrink-0", "bg-emerald-500/10")}>
+          <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+        </div>
+      ) : (
+        <div className={cn("h-5 w-5 rounded-full flex items-center justify-center flex-shrink-0", "bg-red-500/10")}>
+          <XCircle className="h-3 w-3 text-red-500" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SkillDetail({
+  skillId,
+  isOpen,
+  onClose,
+  onDeleted,
+  onUpdated,
+}: SkillDetailProps) {
+  const navigate = useNavigate();
+  const { skill, recentExecutions, isLoading } = useSkillDetail(
+    isOpen ? skillId : null
+  );
+  const mutations = useSkillMutations();
+  const triggerOps = useTriggers(isOpen ? skillId : null);
+  const [showFullPrompt, setShowFullPrompt] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [triggerEditorOpen, setTriggerEditorOpen] = useState(false);
+  const [editingTrigger, setEditingTrigger] = useState<SkillTrigger | null>(null);
+  const [isSavingTrigger, setIsSavingTrigger] = useState(false);
+
+  const handleExport = async () => {
+    if (!skill) return;
+    try {
+      const blob = await exportSkill(skill.id);
+      // Try Electron save dialog first
+      if (window.electronAPI?.saveSkillFile) {
+        const text = await blob.text();
+        const safeName = skill.name.toLowerCase().replace(/\s+/g, "-") + ".think-skill";
+        const result = await window.electronAPI.saveSkillFile(text, safeName);
+        if (result.success) {
+          toast.success("Skill exported");
+        }
+      } else {
+        // Browser fallback
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `${skill.name.toLowerCase().replace(/\s+/g, "-")}.think-skill`;
+        a.click();
+        URL.revokeObjectURL(url);
+        toast.success("Skill exported");
+      }
+    } catch {
+      toast.error("Failed to export skill");
+    }
+  };
+
+  const handleToggleVisibility = async () => {
+    if (!skill) return;
+    try {
+      await mutations.toggleVisibility(skill.id, !skill.hidden);
+      onUpdated();
+      toast.success(skill.hidden ? "Skill is now visible" : "Skill hidden");
+    } catch {
+      toast.error("Failed to toggle visibility");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!skill) return;
+    try {
+      await mutations.remove(skill.id);
+      setShowDeleteDialog(false);
+      onDeleted();
+      toast.success("Skill deleted");
+    } catch {
+      toast.error("Failed to delete skill");
+    }
+  };
+
+  const handleEditTrigger = (trigger: SkillTrigger) => {
+    setEditingTrigger(trigger);
+    setTriggerEditorOpen(true);
+  };
+
+  const handleDeleteTrigger = async (triggerId: number) => {
+    try {
+      await triggerOps.remove(triggerId);
+      toast.success("Trigger deleted");
+    } catch {
+      toast.error("Failed to delete trigger");
+    }
+  };
+
+  const handleToggleTrigger = async (triggerId: number, enabled: boolean) => {
+    try {
+      await triggerOps.toggle(triggerId, enabled);
+      toast.success(enabled ? "Trigger enabled" : "Trigger disabled");
+    } catch {
+      toast.error("Failed to toggle trigger");
+    }
+  };
+
+  const handleSaveTrigger = async (data: TriggerCreateRequest | TriggerUpdateRequest) => {
+    setIsSavingTrigger(true);
+    try {
+      if (editingTrigger) {
+        await triggerOps.update(editingTrigger.id, data);
+        toast.success("Trigger updated");
+      } else {
+        await triggerOps.create(data as TriggerCreateRequest);
+        toast.success("Trigger created");
+      }
+      setTriggerEditorOpen(false);
+      setEditingTrigger(null);
+    } catch {
+      toast.error(editingTrigger ? "Failed to update trigger" : "Failed to create trigger");
+    } finally {
+      setIsSavingTrigger(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const panel = (
+    <div className="fixed inset-0 z-50" onClick={onClose}>
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/20 dark:bg-black/40 backdrop-blur-sm transition-opacity duration-300" />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          "absolute inset-y-0 right-0 w-full max-w-md",
+          "transform transition-all duration-300 ease-out",
+          isOpen ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="h-full bg-background/95 dark:bg-background/98 backdrop-blur-2xl border-l border-white/40 dark:border-white/[0.06] overflow-y-auto">
+          {/* Header */}
+          <div className="sticky top-0 z-10 bg-background/80 backdrop-blur-xl shadow-sm shadow-black/5 dark:shadow-black/20 border-b border-white/40 dark:border-white/[0.06] px-5 py-4 flex items-center justify-between">
+            <div className="flex items-center gap-2 min-w-0">
+              {skill && (
+                <>
+                  <div className="h-8 w-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                    {skill.logo ? (
+                      <img src={skill.logo} alt="" className="h-5 w-5 rounded object-cover" />
+                    ) : (
+                      <span className="text-base">{skill.icon}</span>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <span className="font-semibold text-sm truncate block">{skill.name}</span>
+                    <span className="text-[10px] text-muted-foreground/50 block">
+                      v{skill.version}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+            <Button variant="ghost" size="icon" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {isLoading || !skill ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="px-5 py-5 space-y-6">
+              {/* Description */}
+              <p className="text-sm text-muted-foreground">
+                {skill.description}
+              </p>
+
+              {/* Info Block */}
+              <div className={cn("rounded-xl p-4 divide-y divide-white/30 dark:divide-white/[0.04]", glass.card)}>
+                <div className="flex justify-between text-sm py-2.5 first:pt-0 last:pb-0">
+                  <span className="text-muted-foreground">Category</span>
+                  <span className={cn(chips.base, chips.primary, "text-[10px]")}>
+                    {skill.category}
+                  </span>
+                </div>
+                {skill.tags && skill.tags.length > 0 && (
+                  <div className="flex justify-between text-sm items-start py-2.5 first:pt-0 last:pb-0">
+                    <span className="text-muted-foreground flex-shrink-0">Tags</span>
+                    <div className="flex flex-wrap gap-1 justify-end">
+                      {skill.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className={cn(chips.base, chips.glass, "text-[10px]")}
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {skill.author_name && (
+                  <div className="flex justify-between text-sm py-2.5 first:pt-0 last:pb-0">
+                    <span className="text-muted-foreground">Author</span>
+                    <span>{skill.author_name}</span>
+                  </div>
+                )}
+                <div className="flex justify-between text-sm py-2.5 first:pt-0 last:pb-0">
+                  <span className="text-muted-foreground">Source</span>
+                  <span className="capitalize">
+                    {skill.source ?? "builtin"}
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm py-2.5 first:pt-0 last:pb-0">
+                  <span className="text-muted-foreground">Created</span>
+                  <span>{formatDate(skill.created_at ?? null)}</span>
+                </div>
+              </div>
+
+              {/* Parameters */}
+              {skill.parameters && skill.parameters.length > 0 && (
+                <div>
+                  <h3 className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest mb-3 flex items-center gap-2">
+                    <div className="h-px w-3 bg-primary/40" />
+                    Parameters ({skill.parameters.length})
+                  </h3>
+                  <div className={cn("rounded-xl p-3 space-y-2", glass.card)}>
+                    {skill.parameters.map((p) => (
+                      <div key={p.id} className="text-sm">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{p.label}</span>
+                          <span className="text-[10px] text-muted-foreground/50 px-1.5 py-0.5 rounded bg-muted/50">
+                            {p.type}
+                          </span>
+                        </div>
+                        {p.type === "select" && p.options && (
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {p.options.join(" / ")}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Prompt Preview */}
+              {skill.prompt && (
+                <div>
+                  <button
+                    onClick={() => setShowFullPrompt(!showFullPrompt)}
+                    className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest mb-3 flex items-center gap-2 hover:text-muted-foreground transition-colors"
+                  >
+                    <div className="h-px w-3 bg-primary/40" />
+                    {showFullPrompt ? (
+                      <ChevronDown className="h-3 w-3" />
+                    ) : (
+                      <ChevronRight className="h-3 w-3" />
+                    )}
+                    Prompt Preview
+                  </button>
+                  {showFullPrompt && (
+                    <div className={cn("rounded-xl p-3 space-y-3", glass.card)}>
+                      <div>
+                        <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1">
+                          System
+                        </p>
+                        <pre className="text-xs font-mono whitespace-pre-wrap text-muted-foreground leading-relaxed max-h-32 overflow-y-auto">
+                          {skill.prompt.system}
+                        </pre>
+                      </div>
+                      <div>
+                        <p className="text-[10px] text-muted-foreground/50 uppercase tracking-wider mb-1">
+                          Template
+                        </p>
+                        <pre className="text-xs font-mono whitespace-pre-wrap text-muted-foreground leading-relaxed max-h-32 overflow-y-auto">
+                          {skill.prompt.user_template}
+                        </pre>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Automation */}
+              <div>
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest flex items-center gap-2">
+                    <div className="h-px w-3 bg-primary/40" />
+                    <Zap className="h-3 w-3" />
+                    Automation
+                  </h3>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs text-primary/70 hover:text-primary"
+                    onClick={() => {
+                      setEditingTrigger(null);
+                      setTriggerEditorOpen(true);
+                    }}
+                  >
+                    <Plus className="h-3 w-3 mr-1" />
+                    Trigger
+                  </Button>
+                </div>
+                <TriggerList
+                  triggers={triggerOps.triggers}
+                  onEdit={handleEditTrigger}
+                  onDelete={handleDeleteTrigger}
+                  onToggle={handleToggleTrigger}
+                />
+              </div>
+
+              {/* Actions */}
+              <div>
+                <h3 className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest mb-3 flex items-center gap-2">
+                  <div className="h-px w-3 bg-primary/40" />
+                  Actions
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {skill.source === "user" && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => navigate(`/skills/${skill.id}/edit`)}
+                      className="gap-1.5"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit
+                    </Button>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleExport}
+                    className="gap-1.5 hover:shadow-sm hover:shadow-primary/10 transition-all duration-200"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    Export
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleToggleVisibility}
+                    className="gap-1.5 hover:shadow-sm hover:shadow-primary/10 transition-all duration-200"
+                  >
+                    {skill.hidden ? (
+                      <>
+                        <Eye className="h-3.5 w-3.5" />
+                        Show
+                      </>
+                    ) : (
+                      <>
+                        <EyeOff className="h-3.5 w-3.5" />
+                        Hide
+                      </>
+                    )}
+                  </Button>
+                  {skill.source === "user" && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setShowDeleteDialog(true)}
+                      className="gap-1.5 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-500/10 hover:border-red-500/20 transition-all duration-200"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {/* Recent Executions */}
+              {recentExecutions.length > 0 && (
+                <div>
+                  <h3 className="text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest mb-3 flex items-center gap-2">
+                    <div className="h-px w-3 bg-primary/40" />
+                    <Clock className="h-3 w-3" />
+                    Recent Executions
+                  </h3>
+                  <div className={cn("rounded-xl p-2", glass.card)}>
+                    {recentExecutions.map((ex) => (
+                      <ExecutionItem key={ex.id} execution={ex} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+    </div>
+  );
+
+  return createPortal(
+    <>
+      {panel}
+
+      {/* Dialogs rendered outside the onClick={onClose} tree to prevent
+          React synthetic event propagation from closing the panel */}
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Skill</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete "{skill?.name}"? This will also
+              delete all execution results for this skill.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <TriggerEditor
+        isOpen={triggerEditorOpen}
+        onClose={() => {
+          setTriggerEditorOpen(false);
+          setEditingTrigger(null);
+        }}
+        onSave={handleSaveTrigger}
+        trigger={editingTrigger}
+        isSaving={isSavingTrigger}
+      />
+    </>,
+    document.body
+  );
+}

--- a/app/src/components/SkillEditor.tsx
+++ b/app/src/components/SkillEditor.tsx
@@ -1,0 +1,1370 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Save,
+  Code,
+  Eye,
+  Plus,
+  Trash2,
+  Loader2,
+  AlertCircle,
+  Smile,
+  X,
+  Upload,
+  ImageIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { glass, chips } from "@/lib/design-tokens";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  getSkillWithPrompt,
+  createSkill,
+  updateSkill,
+  type SkillCreateRequest,
+  type SkillParameter,
+} from "@/lib/api";
+import data from "@emoji-mart/data";
+import Picker from "@emoji-mart/react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ParameterForm {
+  id: string;
+  label: string;
+  description: string;
+  type: "select" | "boolean" | "string" | "number";
+  options: string[];
+  default: string;
+}
+
+interface SkillFormState {
+  name: string;
+  description: string;
+  icon: string;
+  logo: string | null;
+  category: string;
+  tags: string[];
+  input_accepts: string[] | null;
+  parameters: ParameterForm[];
+  prompt_system: string;
+  prompt_user_template: string;
+  author_name: string;
+  author_url: string;
+  output_format: string;
+}
+
+interface ValidationErrors {
+  name?: string;
+  description?: string;
+  icon?: string;
+  prompt_system?: string;
+  prompt_user_template?: string;
+  parameters?: Record<number, { id?: string; options?: string; default?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CATEGORIES = [
+  "productivity",
+  "analysis",
+  "export",
+  "writing",
+  "research",
+  "custom",
+] as const;
+
+const MEMORY_TYPES = [
+  { value: "web", label: "Web" },
+  { value: "note", label: "Note" },
+  { value: "voice_memo", label: "Voice Memo" },
+  { value: "audio", label: "Audio" },
+  { value: "video", label: "Video" },
+  { value: "document", label: "Document" },
+] as const;
+
+const VARIABLE_HINTS = [
+  "{{content}}",
+  "{{memory_title}}",
+  "{{memory_url}}",
+  "{{memory_date}}",
+  "{{memory_type}}",
+  "{{memory_tags}}",
+] as const;
+
+const OUTPUT_FORMATS = ["markdown", "plain", "json", "html"] as const;
+
+const MAX_LOGO_BYTES = 32 * 1024;
+
+const EMPTY_FORM: SkillFormState = {
+  name: "",
+  description: "",
+  icon: "",
+  logo: null,
+  category: "custom",
+  tags: [],
+  input_accepts: null,
+  parameters: [],
+  prompt_system: "",
+  prompt_user_template: "",
+  author_name: "",
+  author_url: "",
+  output_format: "markdown",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+function formToCreateRequest(form: SkillFormState): SkillCreateRequest {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    icon: form.icon,
+    logo: form.logo || null,
+    category: form.category,
+    tags: form.tags,
+    input_type: "memory",
+    input_accepts: form.input_accepts,
+    parameters: form.parameters.map((p): SkillParameter => {
+      let defaultValue: unknown = p.default;
+      if (p.type === "boolean") {
+        defaultValue = p.default === "true";
+      } else if (p.type === "number") {
+        defaultValue = parseFloat(p.default) || 0;
+      }
+      return {
+        id: p.id,
+        label: p.label,
+        description: p.description || undefined,
+        type: p.type,
+        options: p.type === "select" ? p.options : undefined,
+        default: defaultValue,
+      };
+    }),
+    prompt_system: form.prompt_system,
+    prompt_user_template: form.prompt_user_template,
+    author_name: form.author_name.trim() || null,
+    author_url: form.author_url.trim() || null,
+    output_format: form.output_format,
+  };
+}
+
+function skillToFormState(skill: Awaited<ReturnType<typeof getSkillWithPrompt>>): SkillFormState {
+  return {
+    name: skill.name,
+    description: skill.description,
+    icon: skill.icon,
+    logo: skill.logo ?? null,
+    category: skill.category,
+    tags: skill.tags ?? [],
+    input_accepts: skill.input?.accepts ?? null,
+    parameters: (skill.parameters ?? []).map((p) => ({
+      id: p.id,
+      label: p.label,
+      description: p.description ?? "",
+      type: p.type,
+      options: p.options ?? [],
+      default: String(p.default ?? ""),
+    })),
+    prompt_system: skill.prompt?.system ?? "",
+    prompt_user_template: skill.prompt?.user_template ?? "",
+    author_name: skill.author_name ?? "",
+    author_url: skill.author_url ?? "",
+    output_format: skill.output_format ?? "markdown",
+  };
+}
+
+function formToJson(form: SkillFormState): string {
+  const obj: Record<string, unknown> = {
+    name: form.name,
+    description: form.description,
+    icon: form.icon,
+    version: "1.0.0",
+    category: form.category,
+    tags: form.tags,
+    input: {
+      type: "memory",
+      accepts: form.input_accepts,
+    },
+    output: {
+      format: form.output_format,
+    },
+    parameters: form.parameters.map((p) => {
+      const param: Record<string, unknown> = {
+        id: p.id,
+        label: p.label,
+        type: p.type,
+        default: p.type === "boolean" ? p.default === "true" : p.type === "number" ? (parseFloat(p.default) || 0) : p.default,
+      };
+      if (p.description) param.description = p.description;
+      if (p.type === "select") param.options = p.options;
+      return param;
+    }),
+    prompt: {
+      system: form.prompt_system,
+      user_template: form.prompt_user_template,
+    },
+  };
+  if (form.logo) {
+    obj.logo = form.logo;
+  }
+  if (form.author_name || form.author_url) {
+    obj.author = {
+      name: form.author_name || undefined,
+      url: form.author_url || undefined,
+    };
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
+function jsonToForm(json: string): SkillFormState {
+  const obj = JSON.parse(json);
+  return {
+    name: obj.name ?? "",
+    description: obj.description ?? "",
+    icon: obj.icon ?? "",
+    logo: obj.logo ?? null,
+    category: obj.category ?? "custom",
+    tags: obj.tags ?? [],
+    input_accepts: obj.input?.accepts ?? null,
+    parameters: (obj.parameters ?? []).map((p: Record<string, unknown>) => ({
+      id: (p.id as string) ?? "",
+      label: (p.label as string) ?? "",
+      description: (p.description as string) ?? "",
+      type: (p.type as ParameterForm["type"]) ?? "string",
+      options: (p.options as string[]) ?? [],
+      default: String(p.default ?? ""),
+    })),
+    prompt_system: obj.prompt?.system ?? "",
+    prompt_user_template: obj.prompt?.user_template ?? "",
+    author_name: obj.author?.name ?? "",
+    author_url: obj.author?.url ?? "",
+    output_format: obj.output?.format ?? "markdown",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export default function SkillEditor() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = Boolean(id);
+
+  const [formState, setFormState] = useState<SkillFormState>(EMPTY_FORM);
+  const [initialFormState, setInitialFormState] = useState<SkillFormState>(EMPTY_FORM);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [jsonView, setJsonView] = useState(false);
+  const [jsonText, setJsonText] = useState("");
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [tagInput, setTagInput] = useState("");
+  const [emojiOpen, setEmojiOpen] = useState(false);
+
+  const templateRef = useRef<HTMLTextAreaElement>(null);
+  const systemRef = useRef<HTMLTextAreaElement>(null);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+
+  // ---- Dirty tracking ----
+  const isDirty = JSON.stringify(formState) !== JSON.stringify(initialFormState);
+
+  // ---- Navigation guard (browser/Electron close + in-app via hashchange) ----
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  useEffect(() => {
+    const beforeUnload = (e: BeforeUnloadEvent) => {
+      if (isDirtyRef.current) {
+        e.preventDefault();
+      }
+    };
+    const hashChange = (e: HashChangeEvent) => {
+      if (isDirtyRef.current) {
+        const confirmed = window.confirm(
+          "You have unsaved changes. Are you sure you want to leave?"
+        );
+        if (!confirmed) {
+          e.preventDefault();
+          // Restore the previous hash
+          window.location.hash = new URL(e.oldURL).hash;
+        }
+      }
+    };
+    window.addEventListener("beforeunload", beforeUnload);
+    window.addEventListener("hashchange", hashChange);
+    return () => {
+      window.removeEventListener("beforeunload", beforeUnload);
+      window.removeEventListener("hashchange", hashChange);
+    };
+  }, []);
+
+  // ---- Load existing skill for edit mode ----
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setIsLoading(true);
+    getSkillWithPrompt(id)
+      .then((skill) => {
+        if (cancelled) return;
+        const form = skillToFormState(skill);
+        setFormState(form);
+        setInitialFormState(form);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        toast.error("Failed to load skill");
+        navigate("/skills");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, navigate]);
+
+  // ---- Field updaters ----
+  const updateField = useCallback(
+    <K extends keyof SkillFormState>(key: K, value: SkillFormState[K]) => {
+      setFormState((prev) => ({ ...prev, [key]: value }));
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[key as keyof ValidationErrors];
+        return next;
+      });
+    },
+    []
+  );
+
+  const updateParameter = useCallback(
+    (index: number, patch: Partial<ParameterForm>) => {
+      setFormState((prev) => {
+        const params = [...prev.parameters];
+        params[index] = { ...params[index], ...patch };
+        // Auto-generate ID from label if label changed and ID was auto-generated
+        if (patch.label !== undefined && !patch.id) {
+          const slug = slugify(patch.label);
+          if (slug) params[index].id = slug;
+        }
+        return { ...prev, parameters: params };
+      });
+      // Clear parameter-level errors
+      setErrors((prev) => {
+        if (!prev.parameters) return prev;
+        const paramsCopy = { ...prev.parameters };
+        const { [index]: _, ...rest } = paramsCopy;
+        return {
+          ...prev,
+          parameters: Object.keys(rest).length > 0 ? rest : undefined,
+        };
+      });
+    },
+    []
+  );
+
+  const addParameter = useCallback(() => {
+    const newParam: ParameterForm = {
+      id: "",
+      label: "",
+      description: "",
+      type: "string",
+      options: [],
+      default: "",
+    };
+    setFormState((prev) => ({
+      ...prev,
+      parameters: [...prev.parameters, newParam],
+    }));
+  }, []);
+
+  const removeParameter = useCallback((index: number) => {
+    setFormState((prev) => ({
+      ...prev,
+      parameters: prev.parameters.filter((_, i) => i !== index),
+    }));
+  }, []);
+
+  // ---- Tag management ----
+  const addTag = useCallback(
+    (tag: string) => {
+      const trimmed = tag.trim().toLowerCase();
+      if (!trimmed) return;
+      if (formState.tags.includes(trimmed)) return;
+      updateField("tags", [...formState.tags, trimmed]);
+    },
+    [formState.tags, updateField]
+  );
+
+  const removeTag = useCallback(
+    (tag: string) => {
+      updateField(
+        "tags",
+        formState.tags.filter((t) => t !== tag)
+      );
+    },
+    [formState.tags, updateField]
+  );
+
+  // ---- Input types management ----
+  const allTypesChecked = formState.input_accepts === null;
+
+  const toggleMemoryType = useCallback(
+    (type: string) => {
+      if (formState.input_accepts === null) {
+        const remaining = MEMORY_TYPES.map((t) => t.value).filter(
+          (t) => t !== type
+        );
+        updateField("input_accepts", remaining);
+      } else if (formState.input_accepts.includes(type)) {
+        const remaining = formState.input_accepts.filter((t) => t !== type);
+        updateField("input_accepts", remaining.length === 0 ? [type] : remaining);
+      } else {
+        const next = [...formState.input_accepts, type];
+        if (next.length === MEMORY_TYPES.length) {
+          updateField("input_accepts", null);
+        } else {
+          updateField("input_accepts", next);
+        }
+      }
+    },
+    [formState.input_accepts, updateField]
+  );
+
+  const toggleAllTypes = useCallback(() => {
+    if (allTypesChecked) {
+      updateField("input_accepts", ["web"]);
+    } else {
+      updateField("input_accepts", null);
+    }
+  }, [allTypesChecked, updateField]);
+
+  const isTypeChecked = (type: string) =>
+    formState.input_accepts === null || formState.input_accepts.includes(type);
+
+  // ---- Logo handlers ----
+  const handleLogoSelect = useCallback((file: File) => {
+    const url = URL.createObjectURL(file);
+    const img = new window.Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      const maxSize = 128;
+      let w = img.width;
+      let h = img.height;
+      if (w > maxSize || h > maxSize) {
+        const ratio = Math.min(maxSize / w, maxSize / h);
+        w = Math.round(w * ratio);
+        h = Math.round(h * ratio);
+      }
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext("2d")!;
+      ctx.drawImage(img, 0, 0, w, h);
+      for (const quality of [0.8, 0.6, 0.4, 0.2]) {
+        const dataUrl = canvas.toDataURL("image/jpeg", quality);
+        if (dataUrl.length <= MAX_LOGO_BYTES) {
+          setFormState((prev) => ({ ...prev, logo: dataUrl }));
+          return;
+        }
+      }
+      setFormState((prev) => ({ ...prev, logo: canvas.toDataURL("image/jpeg", 0.2) }));
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      toast.error("Failed to load image");
+    };
+    img.src = url;
+  }, []);
+
+  const handleLogoFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleLogoSelect(file);
+    e.target.value = "";
+  }, [handleLogoSelect]);
+
+  const handleLogoRemove = useCallback(() => {
+    setFormState((prev) => ({ ...prev, logo: null }));
+  }, []);
+
+  // ---- Variable hint insertion ----
+  const insertVariable = useCallback((variable: string) => {
+    const el = templateRef.current;
+    if (!el) return;
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const val = el.value;
+    const newVal = val.substring(0, start) + variable + val.substring(end);
+    setFormState((prev) => ({ ...prev, prompt_user_template: newVal }));
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(start + variable.length, start + variable.length);
+    });
+  }, []);
+
+  // ---- JSON toggle ----
+  const handleToggleJsonView = useCallback(() => {
+    if (!jsonView) {
+      setJsonText(formToJson(formState));
+      setJsonError(null);
+      setJsonView(true);
+    } else {
+      try {
+        const parsed = jsonToForm(jsonText);
+        setFormState(parsed);
+        setJsonError(null);
+        setJsonView(false);
+      } catch {
+        setJsonError("Invalid JSON. Fix errors before switching back to form view.");
+      }
+    }
+  }, [jsonView, formState, jsonText]);
+
+  // ---- Validation ----
+  const validate = useCallback((): boolean => {
+    const errs: ValidationErrors = {};
+
+    if (!formState.name.trim()) {
+      errs.name = "Name is required";
+    } else if (formState.name.length > 60) {
+      errs.name = "Name must be 60 characters or less";
+    }
+
+    if (!formState.description.trim()) {
+      errs.description = "Description is required";
+    } else if (formState.description.length > 200) {
+      errs.description = "Description must be 200 characters or less";
+    }
+
+    if (!formState.icon) {
+      errs.icon = "Icon is required";
+    }
+
+    if (!formState.prompt_system.trim()) {
+      errs.prompt_system = "System prompt is required";
+    }
+
+    if (!formState.prompt_user_template.includes("{{content}}")) {
+      errs.prompt_user_template = "Template must contain {{content}}";
+    }
+
+    const paramErrors: Record<number, { id?: string; options?: string; default?: string }> = {};
+    const seenIds = new Set<string>();
+
+    formState.parameters.forEach((p, i) => {
+      const pErr: { id?: string; options?: string; default?: string } = {};
+
+      if (!p.id.trim()) {
+        pErr.id = "ID is required";
+      } else if (seenIds.has(p.id)) {
+        pErr.id = "Duplicate parameter ID";
+      }
+      seenIds.add(p.id);
+
+      if (p.type === "select") {
+        if (p.options.length === 0) {
+          pErr.options = "At least one option is required";
+        }
+        if (p.default && p.options.length > 0 && !p.options.includes(p.default)) {
+          pErr.default = "Default must be one of the options";
+        }
+      }
+
+      if (Object.keys(pErr).length > 0) {
+        paramErrors[i] = pErr;
+      }
+    });
+
+    if (Object.keys(paramErrors).length > 0) {
+      errs.parameters = paramErrors;
+    }
+
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  }, [formState]);
+
+  // ---- Save ----
+  const handleSave = useCallback(async () => {
+    if (!validate()) {
+      toast.error("Please fix the validation errors");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const payload = formToCreateRequest(formState);
+
+      if (isEditMode && id) {
+        await updateSkill(id, payload);
+        toast.success("Skill updated");
+      } else {
+        await createSkill(payload);
+        toast.success("Skill created");
+      }
+
+      setInitialFormState(formState);
+      navigate("/skills");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to save skill";
+      toast.error(message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [formState, isEditMode, id, navigate, validate]);
+
+  // ---- Parameter variable hints ----
+  const parameterVariables = formState.parameters
+    .filter((p) => p.id.trim())
+    .map((p) => `{{${p.id}}}`);
+
+  // ---- Loading state ----
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full min-h-[60vh]">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  // ---- Render ----
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-5 space-y-4 pb-20">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate("/skills")}
+            className="shrink-0 hover:bg-primary/10 hover:text-primary transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold font-heading truncate">
+              {isEditMode
+                ? `Edit: ${formState.name || "Untitled"}`
+                : "New Skill"}
+            </h1>
+            <p className="text-xs text-muted-foreground/50 mt-0.5">
+              {isEditMode ? "Modify your skill definition" : "Create a new custom skill"}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleToggleJsonView}
+            className="gap-1.5"
+          >
+            {jsonView ? (
+              <>
+                <Eye className="h-3.5 w-3.5" />
+                View Form
+              </>
+            ) : (
+              <>
+                <Code className="h-3.5 w-3.5" />
+                View JSON
+              </>
+            )}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="gap-1.5 shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all duration-200"
+          >
+            {isSaving ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Save className="h-3.5 w-3.5" />
+            )}
+            Save Skill
+          </Button>
+        </div>
+      </div>
+
+      {/* JSON View */}
+      {jsonView ? (
+        <div className="space-y-3">
+          {jsonError && (
+            <div className="flex items-center gap-2 p-3 rounded-xl bg-destructive/10 border border-destructive/20 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {jsonError}
+            </div>
+          )}
+          <textarea
+            value={jsonText}
+            onChange={(e) => {
+              setJsonText(e.target.value);
+              setJsonError(null);
+            }}
+            className={cn(
+              "w-full min-h-[60vh] rounded-xl p-4 font-mono text-sm resize-y",
+              "border border-white/40 dark:border-white/[0.06]",
+              "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+              "focus:outline-none focus:ring-1 focus:ring-primary/30",
+              "focus:shadow-sm focus:shadow-primary/10 transition-shadow duration-200",
+              jsonError && "border-destructive/50"
+            )}
+            spellCheck={false}
+          />
+        </div>
+      ) : (
+        <>
+          {/* ============================================================= */}
+          {/* Two-column grid: Left (Basics + Input Types), Right (Params)  */}
+          {/* ============================================================= */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+
+            {/* LEFT COLUMN */}
+            <div className="space-y-4">
+              {/* Section 1: Basics */}
+              <section className={cn("rounded-2xl p-4 space-y-3", glass.elevated)}>
+                <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/70 flex items-center gap-2 pb-2 border-b border-white/30 dark:border-white/[0.04]">
+                  <div className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                  Basics
+                </h2>
+
+                {/* Name + Icon inline */}
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium">Name</label>
+                  <div className="flex items-center gap-2">
+                    <Popover open={emojiOpen} onOpenChange={setEmojiOpen}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            "h-9 w-9 rounded-md flex items-center justify-center text-lg shrink-0 transition-all",
+                            "border border-white/50 dark:border-white/[0.08]",
+                            "bg-white/60 dark:bg-white/[0.04] backdrop-blur-sm",
+                            "hover:shadow-md hover:shadow-primary/10 hover:border-primary/30",
+                            formState.icon && "ring-1 ring-primary/20",
+                            errors.icon && "border-red-500/50 ring-1 ring-red-500/20"
+                          )}
+                          title="Pick icon"
+                        >
+                          {formState.icon || <Smile className="h-4 w-4 text-muted-foreground" />}
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className="w-auto p-0 border-0 bg-transparent shadow-none"
+                        align="start"
+                        sideOffset={8}
+                      >
+                        <Picker
+                          data={data}
+                          onEmojiSelect={(emoji: { native: string }) => {
+                            updateField("icon", emoji.native);
+                            setEmojiOpen(false);
+                          }}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <Input
+                      value={formState.name}
+                      onChange={(e) => updateField("name", e.target.value)}
+                      maxLength={60}
+                      placeholder="My Skill"
+                      className={cn("flex-1", errors.name && "border-destructive/50")}
+                    />
+                  </div>
+                  <div className="flex justify-between">
+                    <div className="space-y-0.5">
+                      {errors.icon && (
+                        <p className="text-xs text-destructive">{errors.icon}</p>
+                      )}
+                      {errors.name && (
+                        <p className="text-xs text-destructive">{errors.name}</p>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground/50 ml-auto">
+                      {formState.name.length}/60
+                    </p>
+                  </div>
+                </div>
+
+                {/* Logo */}
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium">Logo</label>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => logoInputRef.current?.click()}
+                      className={cn(
+                        "h-10 w-10 rounded-xl flex items-center justify-center shrink-0 overflow-hidden",
+                        "border border-white/50 dark:border-white/[0.08]",
+                        "bg-white/60 dark:bg-white/[0.04] backdrop-blur-sm",
+                        "hover:shadow-md hover:shadow-primary/10 hover:border-primary/30 transition-all"
+                      )}
+                      title="Upload logo image"
+                    >
+                      {formState.logo ? (
+                        <img
+                          src={formState.logo}
+                          alt="Skill logo"
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <ImageIcon className="h-4 w-4 text-muted-foreground/50" />
+                      )}
+                    </button>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => logoInputRef.current?.click()}
+                        className="gap-1.5 h-7 text-xs px-2.5"
+                      >
+                        <Upload className="h-3 w-3" />
+                        {formState.logo ? "Replace" : "Upload"}
+                      </Button>
+                      {formState.logo && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleLogoRemove}
+                          className="gap-1.5 h-7 text-xs px-2.5 text-muted-foreground hover:text-destructive"
+                        >
+                          <X className="h-3 w-3" />
+                          Remove
+                        </Button>
+                      )}
+                      <span className="text-[11px] text-muted-foreground/50">
+                        {formState.logo
+                          ? "Shown instead of icon"
+                          : "Optional — falls back to icon"}
+                      </span>
+                    </div>
+                    <input
+                      ref={logoInputRef}
+                      type="file"
+                      accept="image/png,image/jpeg,image/svg+xml"
+                      className="hidden"
+                      onChange={handleLogoFileChange}
+                    />
+                  </div>
+                </div>
+
+                {/* Description */}
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium">Description</label>
+                  <Input
+                    value={formState.description}
+                    onChange={(e) => updateField("description", e.target.value)}
+                    maxLength={200}
+                    placeholder="What does this skill do?"
+                    className={cn(errors.description && "border-destructive/50")}
+                  />
+                  <div className="flex justify-between">
+                    {errors.description && (
+                      <p className="text-xs text-destructive">
+                        {errors.description}
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground/50 ml-auto">
+                      {formState.description.length}/200
+                    </p>
+                  </div>
+                </div>
+
+                {/* Category + Output Format side by side */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <label className="text-sm font-medium">Category</label>
+                    <select
+                      value={formState.category}
+                      onChange={(e) => updateField("category", e.target.value)}
+                      className={cn(
+                        "flex h-9 w-full rounded-md px-3 py-1 text-sm",
+                        "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm border border-white/40 dark:border-white/[0.06]",
+                        "shadow-sm transition-colors",
+                        "focus:outline-none focus:ring-1 focus:ring-primary/30 focus:shadow-sm focus:shadow-primary/10"
+                      )}
+                    >
+                      {CATEGORIES.map((cat) => (
+                        <option key={cat} value={cat}>
+                          {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-1.5">
+                    <label className="text-sm font-medium">Output Format</label>
+                    <select
+                      value={formState.output_format}
+                      onChange={(e) => updateField("output_format", e.target.value)}
+                      className={cn(
+                        "flex h-9 w-full rounded-md px-3 py-1 text-sm",
+                        "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm border border-white/40 dark:border-white/[0.06]",
+                        "shadow-sm transition-colors",
+                        "focus:outline-none focus:ring-1 focus:ring-primary/30 focus:shadow-sm focus:shadow-primary/10"
+                      )}
+                    >
+                      {OUTPUT_FORMATS.map((fmt) => (
+                        <option key={fmt} value={fmt}>
+                          {fmt.charAt(0).toUpperCase() + fmt.slice(1)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                {/* Tags */}
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium">Tags</label>
+                  {formState.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mb-1">
+                      {formState.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className={cn(
+                            chips.base,
+                            chips.primary,
+                            "inline-flex items-center gap-1"
+                          )}
+                        >
+                          {tag}
+                          <button
+                            onClick={() => removeTag(tag)}
+                            className="hover:text-destructive transition-colors"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <Input
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addTag(tagInput);
+                        setTagInput("");
+                      }
+                    }}
+                    placeholder="Type a tag and press Enter"
+                  />
+                </div>
+
+                {/* Author */}
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium">Author</label>
+                  <div className="grid grid-cols-2 gap-3">
+                    <Input
+                      value={formState.author_name}
+                      onChange={(e) => updateField("author_name", e.target.value)}
+                      placeholder="Name"
+                    />
+                    <Input
+                      value={formState.author_url}
+                      onChange={(e) => updateField("author_url", e.target.value)}
+                      placeholder="URL (optional)"
+                    />
+                  </div>
+                </div>
+              </section>
+
+              {/* Section 2: Input Types */}
+              <section className={cn("rounded-2xl p-4 space-y-3", glass.card)}>
+                <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/70 flex items-center gap-2 pb-2 border-b border-white/30 dark:border-white/[0.04]">
+                  <div className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                  Input Types
+                </h2>
+
+                <label className="flex items-center gap-2.5 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={allTypesChecked}
+                    onChange={toggleAllTypes}
+                    className="h-4 w-4 rounded border-input accent-primary"
+                  />
+                  <span className="text-sm font-medium">Accept all types</span>
+                </label>
+
+                <div className="grid grid-cols-2 gap-2.5">
+                  {MEMORY_TYPES.map((mt) => (
+                    <label
+                      key={mt.value}
+                      className="flex items-center gap-2.5 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isTypeChecked(mt.value)}
+                        onChange={() => toggleMemoryType(mt.value)}
+                        className="h-4 w-4 rounded border-input accent-primary"
+                      />
+                      <span className="text-sm">{mt.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </section>
+            </div>
+
+            {/* RIGHT COLUMN: Parameters */}
+            <div>
+              <section className={cn("rounded-2xl p-4 space-y-3", glass.card)}>
+                <div className="flex items-center justify-between">
+                  <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/70 flex items-center gap-2 pb-2 border-b border-white/30 dark:border-white/[0.04]">
+                    <div className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+                    Parameters ({formState.parameters.length})
+                  </h2>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={addParameter}
+                    className="gap-1.5"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add
+                  </Button>
+                </div>
+
+                {formState.parameters.length === 0 && (
+                  <p className="text-sm text-muted-foreground/50 text-center py-4">
+                    No parameters defined.
+                  </p>
+                )}
+
+                {formState.parameters.map((param, index) => {
+                  const pErr = errors.parameters?.[index];
+                  return (
+                    <div
+                      key={index}
+                      className={cn("rounded-xl p-3 space-y-2 transition-all duration-200 hover:shadow-sm", glass.panel)}
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider flex items-center gap-1.5">
+                          <div className="h-4 w-4 rounded bg-primary/10 flex items-center justify-center">
+                            <span className="text-[9px] font-bold text-primary">{index + 1}</span>
+                          </div>
+                          Parameter
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeParameter(index)}
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1">
+                          <label className="text-xs text-muted-foreground">Label</label>
+                          <Input
+                            value={param.label}
+                            onChange={(e) =>
+                              updateParameter(index, { label: e.target.value })
+                            }
+                            placeholder="Output Format"
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs text-muted-foreground">ID</label>
+                          <Input
+                            value={param.id}
+                            onChange={(e) =>
+                              updateParameter(index, { id: e.target.value })
+                            }
+                            placeholder="output_format"
+                            className={cn(
+                              "font-mono text-xs",
+                              pErr?.id && "border-destructive/50"
+                            )}
+                          />
+                          {pErr?.id && (
+                            <p className="text-xs text-destructive">{pErr.id}</p>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1">
+                          <label className="text-xs text-muted-foreground">Type</label>
+                          <select
+                            value={param.type}
+                            onChange={(e) =>
+                              updateParameter(index, {
+                                type: e.target.value as ParameterForm["type"],
+                              })
+                            }
+                            className={cn(
+                              "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm",
+                              "shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                            )}
+                          >
+                            <option value="string">String</option>
+                            <option value="number">Number</option>
+                            <option value="boolean">Boolean</option>
+                            <option value="select">Select</option>
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs text-muted-foreground">Default</label>
+                          {param.type === "boolean" ? (
+                            <label className="flex items-center gap-2 h-9 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={param.default === "true"}
+                                onChange={(e) =>
+                                  updateParameter(index, {
+                                    default: e.target.checked ? "true" : "false",
+                                  })
+                                }
+                                className="h-4 w-4 rounded border-input accent-primary"
+                              />
+                              <span className="text-sm">
+                                {param.default === "true" ? "True" : "False"}
+                              </span>
+                            </label>
+                          ) : (
+                            <>
+                              <Input
+                                value={param.default}
+                                onChange={(e) =>
+                                  updateParameter(index, {
+                                    default: e.target.value,
+                                  })
+                                }
+                                placeholder="Default value"
+                                className={cn(
+                                  pErr?.default && "border-destructive/50"
+                                )}
+                              />
+                              {pErr?.default && (
+                                <p className="text-xs text-destructive">
+                                  {pErr.default}
+                                </p>
+                              )}
+                            </>
+                          )}
+                        </div>
+                      </div>
+
+                      {param.type === "select" && (
+                        <div className="space-y-1">
+                          <label className="text-xs text-muted-foreground">
+                            Options (comma-separated)
+                          </label>
+                          <Input
+                            value={param.options.join(", ")}
+                            onChange={(e) =>
+                              updateParameter(index, {
+                                options: e.target.value
+                                  .split(",")
+                                  .map((s) => s.trim())
+                                  .filter(Boolean),
+                              })
+                            }
+                            placeholder="bullet_points, paragraph, table"
+                            className={cn(
+                              pErr?.options && "border-destructive/50"
+                            )}
+                          />
+                          {pErr?.options && (
+                            <p className="text-xs text-destructive">
+                              {pErr.options}
+                            </p>
+                          )}
+                        </div>
+                      )}
+
+                      <div className="space-y-1">
+                        <label className="text-xs text-muted-foreground">Description</label>
+                        <Input
+                          value={param.description}
+                          onChange={(e) =>
+                            updateParameter(index, {
+                              description: e.target.value,
+                            })
+                          }
+                          placeholder="Optional description"
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </section>
+            </div>
+          </div>
+
+          {/* ============================================================= */}
+          {/* Full-width sections: Prompt + Test                            */}
+          {/* ============================================================= */}
+
+          {/* Section: Prompt */}
+          <section className={cn("rounded-2xl p-4 space-y-3", glass.elevated)}>
+            <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/70 flex items-center gap-2 pb-2 border-b border-white/30 dark:border-white/[0.04]">
+              <div className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+              Prompt
+            </h2>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">System Prompt</label>
+              <textarea
+                ref={systemRef}
+                value={formState.prompt_system}
+                onChange={(e) => updateField("prompt_system", e.target.value)}
+                placeholder="You are a helpful assistant that..."
+                className={cn(
+                  "w-full min-h-24 rounded-xl p-3 font-mono text-sm resize-y",
+                  "border border-white/40 dark:border-white/[0.06]",
+                  "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+                  "focus:outline-none focus:ring-1 focus:ring-primary/30",
+                  "focus:shadow-sm focus:shadow-primary/10 transition-shadow duration-200",
+                  "placeholder:text-muted-foreground/50",
+                  errors.prompt_system && "border-destructive/50"
+                )}
+                spellCheck={false}
+              />
+              {errors.prompt_system && (
+                <p className="text-xs text-destructive">
+                  {errors.prompt_system}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs text-muted-foreground/70">
+                Variable Hints — click to insert into template
+              </label>
+              <div className="flex flex-wrap gap-1.5">
+                {[...VARIABLE_HINTS, ...parameterVariables].map((v) => (
+                  <button
+                    key={v}
+                    type="button"
+                    onClick={() => insertVariable(v)}
+                    className={cn(
+                      chips.base,
+                      chips.glass,
+                      "font-mono text-[11px] cursor-pointer hover:bg-primary/10",
+                      "hover:text-primary hover:border-primary/20 hover:shadow-sm hover:shadow-primary/10 active:scale-95 transition-all duration-150"
+                    )}
+                  >
+                    {v}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">User Template</label>
+              <textarea
+                ref={templateRef}
+                value={formState.prompt_user_template}
+                onChange={(e) =>
+                  updateField("prompt_user_template", e.target.value)
+                }
+                placeholder={"Analyze the following content:\n\n{{content}}"}
+                className={cn(
+                  "w-full min-h-28 rounded-xl p-3 font-mono text-sm resize-y",
+                  "border border-white/40 dark:border-white/[0.06]",
+                  "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+                  "focus:outline-none focus:ring-1 focus:ring-primary/30",
+                  "focus:shadow-sm focus:shadow-primary/10 transition-shadow duration-200",
+                  "placeholder:text-muted-foreground/50",
+                  errors.prompt_user_template && "border-destructive/50"
+                )}
+                spellCheck={false}
+              />
+              {errors.prompt_user_template && (
+                <p className="text-xs text-destructive flex items-center gap-1.5">
+                  <AlertCircle className="h-3.5 w-3.5" />
+                  {errors.prompt_user_template}
+                </p>
+              )}
+            </div>
+          </section>
+
+          {/* Section: Test */}
+          <section className={cn("rounded-2xl p-4 space-y-3", glass.panel)}>
+            <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/70 flex items-center gap-2 pb-2 border-b border-white/30 dark:border-white/[0.04]">
+              <div className="h-1.5 w-1.5 rounded-full bg-primary/60" />
+              Test
+            </h2>
+            <SkillTestRunnerLazy formState={formState} />
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lazy wrapper for SkillTestRunner — gracefully handle if not yet implemented
+// ---------------------------------------------------------------------------
+
+function SkillTestRunnerLazy({ formState }: { formState: SkillFormState }) {
+  try {
+    const [Component, setComponent] = useState<React.ComponentType<{
+      formState: SkillFormState;
+    }> | null>(null);
+    const [failed, setFailed] = useState(false);
+
+    useEffect(() => {
+      import("@/components/SkillTestRunner")
+        .then((mod: Record<string, unknown>) => {
+          const Comp = (mod.default || mod.SkillTestRunner) as React.ComponentType<{
+            formState: SkillFormState;
+          }>;
+          setComponent(() => Comp);
+        })
+        .catch(() => {
+          setFailed(true);
+        });
+    }, []);
+
+    if (failed) {
+      return (
+        <p className="text-sm text-muted-foreground/50 text-center py-6">
+          Test runner not available yet. Create the SkillTestRunner component to enable testing.
+        </p>
+      );
+    }
+
+    if (!Component) {
+      return (
+        <div className="flex justify-center py-6">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      );
+    }
+
+    return <Component formState={formState} />;
+  } catch {
+    return (
+      <p className="text-sm text-muted-foreground/50 text-center py-6">
+        Test runner not available yet.
+      </p>
+    );
+  }
+}

--- a/app/src/components/SkillExecutionHistory.tsx
+++ b/app/src/components/SkillExecutionHistory.tsx
@@ -1,0 +1,333 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Search,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  ChevronDown,
+  ArrowRight,
+  Clock,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { glass } from "@/lib/design-tokens";
+import { cn } from "@/lib/utils";
+import { useExecutionHistory, useSkills } from "@/hooks/useSkills";
+import type { ExecutionHistoryItem, ExecutionHistoryFilters } from "@/lib/api";
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDateHeader(dateStr: string): string {
+  const d = new Date(dateStr);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (d.toDateString() === today.toDateString()) return "Today";
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return d.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function ExecutionRow({ execution }: { execution: ExecutionHistoryItem }) {
+  const navigate = useNavigate();
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 p-3.5 rounded-xl transition-all duration-200 group",
+        glass.card,
+        "hover:bg-white/60 dark:hover:bg-white/[0.06] hover:shadow-sm hover:-translate-y-[1px]"
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-white/50 dark:bg-white/[0.04] border border-white/60 dark:border-white/10 flex items-center justify-center flex-shrink-0">
+        {execution.skill_logo ? (
+          <img src={execution.skill_logo} alt="" className="h-4 w-4 rounded object-cover" />
+        ) : (
+          <span className="text-sm">{execution.skill_icon}</span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 text-sm">
+          <span className="font-medium truncate">{execution.skill_name}</span>
+          <ArrowRight className="h-3 w-3 text-muted-foreground/40 flex-shrink-0" />
+          <button
+            onClick={() => navigate(`/memories?open=${execution.memory_id}`)}
+            className="text-muted-foreground truncate hover:text-primary hover:underline transition-colors"
+          >
+            {execution.memory_title || "Untitled"}
+          </button>
+        </div>
+        <div className="flex items-center gap-2 mt-0.5 text-[11px] text-muted-foreground/60">
+          <span>{formatTime(execution.created_at)}</span>
+          {execution.duration_seconds != null && (
+            <span className="flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {execution.duration_seconds}s
+            </span>
+          )}
+          {execution.status === "failed" && execution.error && (
+            <span className="text-red-500/80 truncate max-w-48">
+              {execution.error}
+            </span>
+          )}
+        </div>
+      </div>
+      {execution.status === "completed" ? (
+        <div className={cn("h-6 w-6 rounded-full flex items-center justify-center flex-shrink-0", "bg-emerald-500/10")}>
+          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+        </div>
+      ) : execution.status === "failed" ? (
+        <div className={cn("h-6 w-6 rounded-full flex items-center justify-center flex-shrink-0", "bg-red-500/10")}>
+          <XCircle className="h-3.5 w-3.5 text-red-500" />
+        </div>
+      ) : (
+        <div className={cn("h-6 w-6 rounded-full flex items-center justify-center flex-shrink-0", "bg-amber-500/10")}>
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-500" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SkillExecutionHistory() {
+  const { skills } = useSkills();
+  const [skillFilter, setSkillFilter] = useState("all");
+  const [skillFilterOpen, setSkillFilterOpen] = useState(false);
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [statusFilterOpen, setStatusFilterOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce search
+  useEffect(() => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+    }, 300);
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, [searchQuery]);
+
+  const filters: ExecutionHistoryFilters = useMemo(
+    () => ({
+      skill_id: skillFilter !== "all" ? skillFilter : undefined,
+      status:
+        statusFilter !== "all"
+          ? (statusFilter as "completed" | "failed")
+          : undefined,
+      search: debouncedSearch || undefined,
+      limit: 20,
+    }),
+    [skillFilter, statusFilter, debouncedSearch]
+  );
+
+  const { executions, total, isLoading, hasMore, loadMore } =
+    useExecutionHistory(filters);
+
+  // Infinite scroll sentinel
+  const loadMoreRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !isLoading) {
+          loadMore();
+        }
+      },
+      { threshold: 0.1 }
+    );
+    if (loadMoreRef.current) observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, loadMore]);
+
+  // Group executions by date
+  const grouped = useMemo(() => {
+    const groups: Map<string, ExecutionHistoryItem[]> = new Map();
+    for (const ex of executions) {
+      const dateKey = new Date(ex.created_at).toDateString();
+      if (!groups.has(dateKey)) groups.set(dateKey, []);
+      groups.get(dateKey)!.push(ex);
+    }
+    return groups;
+  }, [executions]);
+
+  return (
+    <div>
+      {/* Filters */}
+      <div className={cn("flex items-center gap-2 mb-6 p-2 rounded-xl", glass.overlay)}>
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground/50" />
+          <Input
+            placeholder="Search by memory title..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9 h-9"
+          />
+        </div>
+
+        {/* Skill filter */}
+        <Popover open={skillFilterOpen} onOpenChange={setSkillFilterOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5 h-9">
+              {skillFilter === "all"
+                ? "All Skills"
+                : skills.find((s) => s.id === skillFilter)?.name ?? "Skill"}
+              <ChevronDown className="h-3 w-3 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-52 p-1 max-h-64 overflow-y-auto" align="end">
+            <button
+              onClick={() => {
+                setSkillFilter("all");
+                setSkillFilterOpen(false);
+              }}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors",
+                skillFilter === "all"
+                  ? "bg-primary/10 text-primary"
+                  : "hover:bg-muted"
+              )}
+            >
+              All Skills
+            </button>
+            {skills.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => {
+                  setSkillFilter(s.id);
+                  setSkillFilterOpen(false);
+                }}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-2",
+                  skillFilter === s.id
+                    ? "bg-primary/10 text-primary"
+                    : "hover:bg-muted"
+                )}
+              >
+                {s.logo ? (
+                  <img src={s.logo} alt="" className="h-4 w-4 rounded object-cover" />
+                ) : (
+                  <span>{s.icon}</span>
+                )}
+                <span className="truncate">{s.name}</span>
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+
+        {/* Status filter */}
+        <Popover open={statusFilterOpen} onOpenChange={setStatusFilterOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5 h-9">
+              {statusFilter === "all"
+                ? "All Status"
+                : statusFilter === "completed"
+                  ? "Completed"
+                  : "Failed"}
+              <ChevronDown className="h-3 w-3 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-36 p-1" align="end">
+            {[
+              { value: "all", label: "All Status" },
+              { value: "completed", label: "Completed" },
+              { value: "failed", label: "Failed" },
+            ].map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => {
+                  setStatusFilter(opt.value);
+                  setStatusFilterOpen(false);
+                }}
+                className={cn(
+                  "w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors",
+                  statusFilter === opt.value
+                    ? "bg-primary/10 text-primary"
+                    : "hover:bg-muted"
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* Results count */}
+      {total > 0 && (
+        <div className="flex items-center gap-2 mb-4">
+          <div className="h-1.5 w-1.5 rounded-full bg-primary/50" />
+          <p className="text-xs text-muted-foreground/50">
+            {total} execution{total !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
+
+      {/* Grouped list */}
+      {isLoading && executions.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : executions.length === 0 ? (
+        <div className="text-center py-20 animate-fade-in-up">
+          <div className="h-16 w-16 mx-auto rounded-2xl bg-primary/5 flex items-center justify-center mb-4">
+            <Clock className="h-10 w-10 text-muted-foreground/30" />
+          </div>
+          <p className="text-muted-foreground">
+            {debouncedSearch || skillFilter !== "all" || statusFilter !== "all"
+              ? "No executions match your filters."
+              : "No skill executions yet."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {Array.from(grouped.entries()).map(([dateKey, execs]) => (
+            <div key={dateKey}>
+              <div className="flex items-center gap-3 mb-3 px-1">
+                <h3 className="text-[11px] font-semibold text-muted-foreground/50 uppercase tracking-widest whitespace-nowrap">
+                  {formatDateHeader(execs[0].created_at)}
+                </h3>
+                <div className="flex-1 h-px bg-border/40" />
+              </div>
+              <div className="space-y-2">
+                {execs.map((ex, index) => (
+                  <div
+                    key={ex.id}
+                    className="animate-stagger-fade-in opacity-0"
+                    style={{
+                      animationDelay: `${Math.min(index * 40, 1000)}ms`,
+                      animationFillMode: 'forwards',
+                    }}
+                  >
+                    <ExecutionRow execution={ex} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Load more sentinel */}
+      {hasMore && <div ref={loadMoreRef} className="h-1" />}
+      {isLoading && executions.length > 0 && (
+        <div className="flex justify-center py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/SkillImportDialog.tsx
+++ b/app/src/components/SkillImportDialog.tsx
@@ -1,0 +1,485 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Upload,
+  FileText,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+import {
+  validateSkillDefinition,
+  importSkill,
+  getSkillsList,
+  type SkillListItem,
+  type SkillValidationResult,
+} from "@/lib/api";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { glass } from "@/lib/design-tokens";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SkillImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialContent?: string | null;
+  onImported: (skill: SkillListItem) => void;
+}
+
+type ConflictResolution = "replace" | "copy";
+
+interface CollisionInfo {
+  existingSkill: SkillListItem;
+  isBuiltin: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SkillImportDialog({
+  open,
+  onOpenChange,
+  initialContent,
+  onImported,
+}: SkillImportDialogProps) {
+  // ---- State ----
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [validation, setValidation] = useState<SkillValidationResult | null>(null);
+  const [collision, setCollision] = useState<CollisionInfo | null>(null);
+  const [conflictResolution, setConflictResolution] = useState<ConflictResolution>("copy");
+  const [isValidating, setIsValidating] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // ---- Derived ----
+  const content = initialContent ?? fileContent;
+  const canImport = validation?.valid === true && !isValidating && !isImporting;
+
+  // ---- Reset on close ----
+  const resetState = useCallback(() => {
+    setFileContent(null);
+    setFileName(null);
+    setValidation(null);
+    setCollision(null);
+    setConflictResolution("copy");
+    setIsValidating(false);
+    setIsImporting(false);
+    setIsDragOver(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      resetState();
+    }
+  }, [open, resetState]);
+
+  // ---- Validate when content changes ----
+  const validate = useCallback(async (raw: string) => {
+    setIsValidating(true);
+    setValidation(null);
+    setCollision(null);
+    setConflictResolution("copy");
+
+    try {
+      const result = await validateSkillDefinition(raw);
+      setValidation(result);
+
+      // Collision check – only if valid and we have a parsed ID
+      if (result.valid && result.parsed?.id) {
+        try {
+          const allSkills = await getSkillsList({ include_hidden: true });
+          const existing = allSkills.find((s) => s.id === result.parsed!.id);
+          if (existing) {
+            const isBuiltin = existing.source === "builtin";
+            setCollision({ existingSkill: existing, isBuiltin });
+            // Default to "copy" since replace might not be allowed
+            setConflictResolution(isBuiltin ? "copy" : "copy");
+          }
+        } catch {
+          // Non-critical – we just skip the collision check
+          console.warn("Could not check for skill ID collision");
+        }
+      }
+    } catch (err) {
+      setValidation({
+        valid: false,
+        errors: [err instanceof Error ? err.message : "Validation request failed"],
+      });
+    } finally {
+      setIsValidating(false);
+    }
+  }, []);
+
+  // Re-validate when initialContent changes while dialog is open
+  useEffect(() => {
+    if (open && initialContent) {
+      validate(initialContent);
+    }
+  }, [open, initialContent, validate]);
+
+  // Also validate when user picks a file
+  useEffect(() => {
+    if (open && fileContent) {
+      validate(fileContent);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, fileContent]);
+
+  // ---- File reading helpers ----
+  const readFile = useCallback((file: File) => {
+    setFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result;
+      if (typeof text === "string") {
+        setFileContent(text);
+      }
+    };
+    reader.onerror = () => {
+      toast.error("Failed to read file");
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) {
+        readFile(file);
+      }
+    },
+    [readFile],
+  );
+
+  // ---- Drag & drop handlers ----
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragOver(false);
+
+      const file = e.dataTransfer.files?.[0];
+      if (file) {
+        readFile(file);
+      }
+    },
+    [readFile],
+  );
+
+  // ---- Import handler ----
+  const handleImport = useCallback(async () => {
+    if (!content) return;
+
+    setIsImporting(true);
+    try {
+      const skill = await importSkill({
+        definition: content,
+        conflict_resolution: conflictResolution,
+      });
+      toast.success(`Skill "${skill.name}" imported successfully`);
+      onImported(skill);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to import skill",
+      );
+    } finally {
+      setIsImporting(false);
+    }
+  }, [content, conflictResolution, onImported, onOpenChange]);
+
+  // ---- Render helpers ----
+  const hasContent = content != null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import Skill</DialogTitle>
+          <DialogDescription>
+            Import a <code className="text-xs">.think-skill</code> or JSON file
+            to add a new skill.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* ---------- File input / drag-and-drop ---------- */}
+          {!initialContent && (
+            <>
+              <div
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+                className={cn(
+                  "relative flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed px-6 py-10 cursor-pointer transition-all duration-200",
+                  glass.card,
+                  isDragOver
+                    ? "border-primary bg-primary/5 shadow-lg shadow-primary/10 scale-[1.01]"
+                    : "border-muted-foreground/25 hover:border-primary/50 hover:bg-accent/50",
+                )}
+              >
+                <div
+                  className={cn(
+                    "h-12 w-12 rounded-xl flex items-center justify-center transition-all duration-200",
+                    isDragOver ? "bg-primary/15 scale-110" : "bg-muted/50"
+                  )}
+                >
+                  <Upload
+                    className={cn(
+                      "h-6 w-6 transition-colors",
+                      isDragOver ? "text-primary" : "text-muted-foreground/60",
+                    )}
+                  />
+                </div>
+                <p className="text-sm text-muted-foreground text-center">
+                  {fileName ? (
+                    <span className="flex items-center gap-1.5">
+                      <FileText className="h-4 w-4 inline-block" />
+                      {fileName}
+                    </span>
+                  ) : (
+                    <>
+                      Drag & drop a{" "}
+                      <code className="text-xs">.think-skill</code> file here
+                    </>
+                  )}
+                </p>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".think-skill,.json"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+              </div>
+
+              {!fileName && (
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 border-t border-border" />
+                  <span className="text-xs text-muted-foreground uppercase tracking-wider">
+                    or
+                  </span>
+                  <div className="flex-1 border-t border-border" />
+                </div>
+              )}
+
+              {!fileName && (
+                <div className="flex justify-center">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <FileText className="h-4 w-4 mr-2" />
+                    Choose File
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* ---------- Validating spinner ---------- */}
+          {isValidating && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Validating skill definition...
+            </div>
+          )}
+
+          {/* ---------- Validation results ---------- */}
+          {validation && !isValidating && (
+            <div
+              className={cn(
+                "rounded-xl border p-4 space-y-2 animate-scale-in",
+                glass.card,
+                validation.valid
+                  ? "border-l-2 border-emerald-500/40"
+                  : "border-l-2 border-red-500/40",
+              )}
+            >
+              <p className="text-sm font-medium">Validation Results</p>
+
+              {validation.valid ? (
+                <div className="space-y-2">
+                  <div className="flex items-start gap-2 text-sm text-green-600 dark:text-green-400">
+                    <div className="h-5 w-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
+                      <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                    </div>
+                    <span>
+                      Valid skill definition
+                      {validation.parsed?.name && (
+                        <>
+                          : <strong>{validation.parsed.name}</strong>
+                        </>
+                      )}
+                    </span>
+                  </div>
+
+                  {validation.parsed?.id && (
+                    <p className="text-xs text-muted-foreground pl-6 font-mono break-all">
+                      id: {validation.parsed.id}
+                    </p>
+                  )}
+
+                  {validation.warnings && validation.warnings.length > 0 && (
+                    <div className="space-y-1 pt-1">
+                      {validation.warnings.map((warning, i) => (
+                        <div
+                          key={i}
+                          className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-400"
+                        >
+                          <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                          <span>{warning}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  {validation.errors?.map((error, i) => (
+                    <div
+                      key={i}
+                      className="flex items-start gap-2 text-sm text-red-600 dark:text-red-400"
+                    >
+                      <div className="h-5 w-5 rounded-full bg-red-500/10 flex items-center justify-center">
+                        <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                      </div>
+                      <span>{error}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ---------- Collision resolution ---------- */}
+          {collision && validation?.valid && !isValidating && (
+            <div
+              className={cn(
+                "rounded-xl border border-l-2 border-amber-500/40 p-4 space-y-3 animate-fade-in-up",
+                glass.card,
+              )}
+            >
+              <div className="flex items-start gap-2 text-sm text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>
+                  A skill with this ID already exists:{" "}
+                  <strong>{collision.existingSkill.name}</strong>
+                </span>
+              </div>
+
+              <fieldset className="space-y-2 pl-6">
+                <label
+                  className={cn(
+                    "flex items-center gap-2.5 text-sm p-2 rounded-lg transition-colors",
+                    "hover:bg-white/30 dark:hover:bg-white/[0.03]",
+                    collision.isBuiltin && "opacity-50 cursor-not-allowed",
+                    conflictResolution === "replace" && "bg-primary/5",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="conflict_resolution"
+                    value="replace"
+                    checked={conflictResolution === "replace"}
+                    disabled={collision.isBuiltin}
+                    onChange={() => setConflictResolution("replace")}
+                    className="accent-primary"
+                  />
+                  <span>
+                    Replace existing
+                    {collision.isBuiltin && (
+                      <span className="text-xs text-muted-foreground ml-1">
+                        (built-in skills cannot be replaced)
+                      </span>
+                    )}
+                  </span>
+                </label>
+
+                <label
+                  className={cn(
+                    "flex items-center gap-2.5 text-sm p-2 rounded-lg transition-colors",
+                    "hover:bg-white/30 dark:hover:bg-white/[0.03]",
+                    conflictResolution === "copy" && "bg-primary/5",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="conflict_resolution"
+                    value="copy"
+                    checked={conflictResolution === "copy"}
+                    onChange={() => setConflictResolution("copy")}
+                    className="accent-primary"
+                  />
+                  <span>Import as copy (new ID)</span>
+                </label>
+              </fieldset>
+            </div>
+          )}
+        </div>
+
+        {/* ---------- Footer ---------- */}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isImporting}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!canImport || !hasContent}
+            onClick={handleImport}
+            className={cn(
+              canImport && hasContent
+                ? "shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all duration-200"
+                : ""
+            )}
+          >
+            {isImporting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                Importing...
+              </>
+            ) : (
+              <>
+                <Upload className="h-4 w-4 mr-2" />
+                Import
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/SkillRunner.tsx
+++ b/app/src/components/SkillRunner.tsx
@@ -1,0 +1,976 @@
+import React, { useState, useEffect, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import {
+  ChevronLeft,
+  X,
+  Zap,
+  Copy,
+  RefreshCw,
+  Loader2,
+  Eye,
+  AlertTriangle,
+  Check,
+  Clock,
+  ChevronDown,
+  ChevronUp,
+  Globe,
+  FileText,
+  Mic,
+  FileAudio,
+  Video,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { glass, chips, getMemoryTypeColor } from "@/lib/design-tokens";
+import { getSkillWithPrompt, type Skill, type SkillExecution } from "@/lib/api";
+import { useSkills, useSkillExecution, useSkillHistory } from "@/hooks/useSkills";
+import { toast } from "sonner";
+
+// --- Types ---
+
+interface SkillRunnerMemory {
+  id: number;
+  type: string;
+  title: string;
+  content?: string;
+  transcript?: string;
+  summary: string | null;
+}
+
+interface SkillRunnerProps {
+  memoryId: number;
+  memory: SkillRunnerMemory;
+  onClose: () => void;
+  formatDate: (date: string) => string;
+  initialExecutionId?: number | null;
+}
+
+type SkillRunnerView =
+  | { screen: "selection" }
+  | { screen: "skill"; skillId: string; tab: "configure" | "result" | "history"; viewingExecution?: SkillExecution | null };
+
+// --- Helper: Memory type icon ---
+
+function MemoryTypeIcon({ type, className }: { type: string; className?: string }) {
+  const base = className || "h-3.5 w-3.5";
+  switch (type) {
+    case "web": return <Globe className={base} />;
+    case "voice_memo":
+    case "voice": return <Mic className={base} />;
+    case "audio": return <FileAudio className={base} />;
+    case "video": return <Video className={base} />;
+    case "document": return <FileText className={base} />;
+    default: return <FileText className={base} />;
+  }
+}
+
+function memoryTypeLabel(type: string): string {
+  switch (type) {
+    case "voice_memo":
+    case "voice": return "Voice Memo";
+    default: return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+}
+
+// --- Main Component ---
+
+export function SkillRunner({
+  memoryId,
+  memory,
+  onClose,
+  formatDate,
+  initialExecutionId,
+}: SkillRunnerProps) {
+  const [view, setView] = useState<SkillRunnerView>({ screen: "selection" });
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
+  const { skills, isLoading: isLoadingSkills } = useSkills();
+  const skillExecution = useSkillExecution();
+  const { executions, refresh: refreshHistory } = useSkillHistory(memoryId);
+  const [params, setParams] = useState<Record<string, unknown>>({});
+
+  // Handle initial execution view (from Skill Results section)
+  useEffect(() => {
+    if (initialExecutionId && executions.length > 0) {
+      const execution = executions.find((e) => e.id === initialExecutionId);
+      if (execution) {
+        const skill = skills.find((s) => s.id === execution.skill_id);
+        if (skill) {
+          setSelectedSkill(skill);
+          setView({
+            screen: "skill",
+            skillId: skill.id,
+            tab: "result",
+            viewingExecution: execution,
+          });
+        }
+      }
+    }
+  }, [initialExecutionId, executions, skills]);
+
+  const handleSelectSkill = (skill: Skill) => {
+    setSelectedSkill(skill);
+    const defaults: Record<string, unknown> = {};
+    for (const p of skill.parameters) {
+      defaults[p.id] = p.default;
+    }
+    setParams(defaults);
+    skillExecution.reset();
+    setView({ screen: "skill", skillId: skill.id, tab: "configure" });
+  };
+
+  const handleBack = () => {
+    if (view.screen === "skill") {
+      skillExecution.reset();
+      setSelectedSkill(null);
+      setView({ screen: "selection" });
+    } else {
+      onClose();
+    }
+  };
+
+  const handleRun = async () => {
+    if (!selectedSkill) return;
+    setView({ screen: "skill", skillId: selectedSkill.id, tab: "result", viewingExecution: null });
+    await skillExecution.execute({
+      skill_id: selectedSkill.id,
+      memory_id: memoryId,
+      parameters: params,
+    });
+    refreshHistory();
+  };
+
+  const handleRerun = () => {
+    if (!selectedSkill) return;
+    setView({ screen: "skill", skillId: selectedSkill.id, tab: "configure" });
+  };
+
+  const handleViewExecution = (execution: SkillExecution) => {
+    const skill = skills.find((s) => s.id === execution.skill_id);
+    if (skill) {
+      setSelectedSkill(skill);
+      setView({
+        screen: "skill",
+        skillId: skill.id,
+        tab: "result",
+        viewingExecution: execution,
+      });
+    }
+  };
+
+  const isSkillCompatible = (skill: Skill) => {
+    if (!skill.input.accepts) return true;
+    return skill.input.accepts.includes(memory.type);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/20">
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={handleBack}
+            className={cn(
+              "h-8 w-8 flex items-center justify-center rounded-xl transition-all duration-200",
+              glass.card,
+              "hover:shadow-md hover:scale-[1.02]"
+            )}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          {view.screen === "skill" && selectedSkill ? (
+            <div className="flex items-center gap-2">
+              <span className="text-lg leading-none">
+                {selectedSkill.logo ? (
+                  <img src={selectedSkill.logo} alt="" className="h-5 w-5 rounded" />
+                ) : (
+                  selectedSkill.icon
+                )}
+              </span>
+              <span className="text-sm font-medium">{selectedSkill.name}</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <Zap className="h-4 w-4 text-primary" />
+              <span className="text-sm font-medium">Skills</span>
+            </div>
+          )}
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose} className="h-8 w-8">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {view.screen === "selection" && (
+          <SkillSelectionView
+            skills={skills}
+            isLoading={isLoadingSkills}
+            memory={memory}
+            isSkillCompatible={isSkillCompatible}
+            onSelect={handleSelectSkill}
+          />
+        )}
+
+        {view.screen === "skill" && selectedSkill && (
+          <SkillDetailView
+            skill={selectedSkill}
+            memory={memory}
+            params={params}
+            setParams={setParams}
+            tab={view.tab}
+            setTab={(tab) =>
+              setView((prev) =>
+                prev.screen === "skill" ? { ...prev, tab } : prev
+              )
+            }
+            viewingExecution={view.viewingExecution ?? null}
+            execution={skillExecution}
+            executions={executions}
+            formatDate={formatDate}
+            onRun={handleRun}
+            onRerun={handleRerun}
+            onViewExecution={handleViewExecution}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Skill Selection View ---
+
+function SkillSelectionView({
+  skills,
+  isLoading,
+  memory,
+  isSkillCompatible,
+  onSelect,
+}: {
+  skills: Skill[];
+  isLoading: boolean;
+  memory: SkillRunnerMemory;
+  isSkillCompatible: (skill: Skill) => boolean;
+  onSelect: (skill: Skill) => void;
+}) {
+  const typeColor = getMemoryTypeColor(memory.type);
+
+  if (isLoading) {
+    return (
+      <div className="p-6 flex items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 space-y-4">
+      {/* Target memory card */}
+      <div className={cn("px-4 py-3 rounded-2xl flex items-center gap-3", glass.card)}>
+        <div
+          className="flex items-center justify-center h-8 w-8 rounded-xl"
+          style={{ backgroundColor: `${typeColor.hex}15` }}
+        >
+          <MemoryTypeIcon type={memory.type} className={cn("h-4 w-4", typeColor.text)} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-muted-foreground">{memoryTypeLabel(memory.type)}</p>
+          <p className="text-sm font-medium truncate">{memory.title || "Untitled"}</p>
+        </div>
+      </div>
+
+      {/* Skill cards */}
+      {skills.filter(isSkillCompatible).map((skill, index) => (
+        <button
+          key={skill.id}
+          onClick={() => onSelect(skill)}
+          className={cn(
+            "w-full text-left p-4 rounded-2xl transition-all duration-200 animate-fade-in-up",
+            glass.base,
+            glass.hover,
+            "cursor-pointer"
+          )}
+          style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
+        >
+          <div className="flex items-start gap-3.5">
+            <div className="flex items-center justify-center h-10 w-10 rounded-xl bg-primary/5 text-xl leading-none shrink-0">
+              {skill.logo ? (
+                <img src={skill.logo} alt="" className="h-6 w-6 rounded" />
+              ) : (
+                skill.icon
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium">{skill.name}</div>
+              <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                {skill.description}
+              </div>
+              <span className={cn(chips.base, chips.primary, "mt-2 inline-block")}>
+                {skill.category}
+              </span>
+            </div>
+          </div>
+        </button>
+      ))}
+
+      {skills.length === 0 && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <Zap className="h-8 w-8 mb-2 opacity-30" />
+          <p className="text-sm">No skills available</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Skill Detail View (Tabs) ---
+
+function SkillDetailView({
+  skill,
+  memory,
+  params,
+  setParams,
+  tab,
+  setTab,
+  viewingExecution,
+  execution,
+  executions,
+  formatDate,
+  onRun,
+  onRerun,
+  onViewExecution,
+}: {
+  skill: Skill;
+  memory: SkillRunnerMemory;
+  params: Record<string, unknown>;
+  setParams: (p: Record<string, unknown>) => void;
+  tab: "configure" | "result" | "history";
+  setTab: (tab: "configure" | "result" | "history") => void;
+  viewingExecution: SkillExecution | null;
+  execution: ReturnType<typeof useSkillExecution>;
+  executions: SkillExecution[];
+  formatDate: (date: string) => string;
+  onRun: () => void;
+  onRerun: () => void;
+  onViewExecution: (execution: SkillExecution) => void;
+}) {
+  const showResultTab = execution.state !== "idle" || viewingExecution !== null;
+
+  return (
+    <div className="flex flex-col">
+      {/* Segmented Control Tabs */}
+      <div className="px-4 pt-4 pb-2">
+        <div className="flex bg-muted/30 rounded-xl p-1">
+          <button
+            onClick={() => setTab("configure")}
+            className={cn(
+              "flex-1 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200",
+              tab === "configure"
+                ? "bg-primary/10 text-primary shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            Configure
+          </button>
+          {showResultTab && (
+            <button
+              onClick={() => setTab("result")}
+              className={cn(
+                "flex-1 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-1.5",
+                tab === "result"
+                  ? "bg-primary/10 text-primary shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              Result
+              {execution.state === "running" && (
+                <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />
+              )}
+            </button>
+          )}
+          <button
+            onClick={() => setTab("history")}
+            className={cn(
+              "flex-1 px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200",
+              tab === "history"
+                ? "bg-primary/10 text-primary shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            History
+          </button>
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="p-5">
+        {tab === "configure" && (
+          <SkillConfigureTab
+            skill={skill}
+            memory={memory}
+            params={params}
+            setParams={setParams}
+            onRun={onRun}
+            isRunning={execution.state === "running"}
+          />
+        )}
+        {tab === "result" && (
+          <SkillResultTab
+            execution={execution}
+            viewingExecution={viewingExecution}
+            skillName={skill.name}
+            onRerun={onRerun}
+            outputFormat={skill.output_format}
+          />
+        )}
+        {tab === "history" && (
+          <SkillHistoryTab
+            executions={executions}
+            formatDate={formatDate}
+            onView={onViewExecution}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Configure Tab ---
+
+function SkillConfigureTab({
+  skill,
+  memory,
+  params,
+  setParams,
+  onRun,
+  isRunning,
+}: {
+  skill: Skill;
+  memory: SkillRunnerMemory;
+  params: Record<string, unknown>;
+  setParams: (p: Record<string, unknown>) => void;
+  onRun: () => void;
+  isRunning: boolean;
+}) {
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [promptData, setPromptData] = useState<{ system: string; user_template: string } | null>(null);
+  const [isLoadingPrompt, setIsLoadingPrompt] = useState(false);
+
+  const typeColor = getMemoryTypeColor(memory.type);
+
+  const handleViewPrompt = async () => {
+    if (showPrompt) {
+      setShowPrompt(false);
+      return;
+    }
+    if (!promptData) {
+      setIsLoadingPrompt(true);
+      try {
+        const data = await getSkillWithPrompt(skill.id);
+        if (data.prompt) {
+          setPromptData(data.prompt);
+        }
+      } catch {
+        toast.error("Failed to load prompt");
+      } finally {
+        setIsLoadingPrompt(false);
+      }
+    }
+    setShowPrompt(true);
+  };
+
+  const updateParam = (id: string, value: unknown) => {
+    setParams({ ...params, [id]: value });
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Target memory card */}
+      <div className={cn("px-4 py-3 rounded-2xl flex items-center gap-3", glass.card)}>
+        <div
+          className="flex items-center justify-center h-8 w-8 rounded-xl"
+          style={{ backgroundColor: `${typeColor.hex}15` }}
+        >
+          <MemoryTypeIcon type={memory.type} className={cn("h-4 w-4", typeColor.text)} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-muted-foreground">{memoryTypeLabel(memory.type)}</p>
+          <p className="text-sm font-medium truncate">{memory.title || "Untitled"}</p>
+        </div>
+      </div>
+
+      {/* Parameters */}
+      {skill.parameters.length > 0 && (
+        <div className="space-y-3">
+          <h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Parameters
+          </h4>
+          {skill.parameters.map((param) => (
+            <div key={param.id} className={cn("p-4 rounded-2xl space-y-2.5", glass.card)}>
+              <div>
+                <label className="text-sm font-medium">{param.label}</label>
+                {param.description && (
+                  <p className="text-xs text-muted-foreground mt-0.5">{param.description}</p>
+                )}
+              </div>
+
+              {param.type === "select" && param.options && (
+                <div className="flex flex-wrap gap-1.5">
+                  {param.options.map((opt) => (
+                    <button
+                      key={opt}
+                      onClick={() => updateParam(param.id, opt)}
+                      className={cn(
+                        chips.base,
+                        "transition-all duration-200",
+                        params[param.id] === opt
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : cn(chips.glass, "hover:bg-primary/10")
+                      )}
+                    >
+                      {opt}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {param.type === "boolean" && (
+                <div className="flex gap-1.5">
+                  {["Yes", "No"].map((label) => {
+                    const val = label === "Yes";
+                    return (
+                      <button
+                        key={label}
+                        onClick={() => updateParam(param.id, val)}
+                        className={cn(
+                          chips.base,
+                          "transition-all duration-200",
+                          params[param.id] === val
+                            ? "bg-primary text-primary-foreground shadow-sm"
+                            : cn(chips.glass, "hover:bg-primary/10")
+                        )}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {param.type === "string" && (
+                <input
+                  type="text"
+                  value={(params[param.id] as string) || ""}
+                  onChange={(e) => updateParam(param.id, e.target.value)}
+                  className={cn(
+                    "w-full px-3 py-1.5 text-sm rounded-xl border border-white/40 dark:border-white/[0.06]",
+                    "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm focus:outline-none focus:ring-1 focus:ring-primary/30"
+                  )}
+                />
+              )}
+
+              {param.type === "number" && (
+                <input
+                  type="number"
+                  value={(params[param.id] as number) ?? ""}
+                  onChange={(e) => updateParam(param.id, parseFloat(e.target.value) || 0)}
+                  className={cn(
+                    "w-full px-3 py-1.5 text-sm rounded-xl border border-white/40 dark:border-white/[0.06]",
+                    "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm focus:outline-none focus:ring-1 focus:ring-primary/30"
+                  )}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Run button */}
+      <Button
+        onClick={onRun}
+        disabled={isRunning}
+        className="w-full bg-primary hover:bg-primary/90 shadow-lg shadow-primary/20 transition-all duration-200"
+      >
+        {isRunning ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Running...
+          </>
+        ) : (
+          <>
+            <Zap className="h-4 w-4 mr-2" />
+            Run Skill
+          </>
+        )}
+      </Button>
+
+      {/* View Prompt */}
+      <button
+        onClick={handleViewPrompt}
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {isLoadingPrompt ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Eye className="h-3.5 w-3.5" />
+        )}
+        View Prompt
+        {showPrompt ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+      </button>
+
+      {showPrompt && promptData && (
+        <div className="space-y-2">
+          <div className={cn("rounded-2xl p-4", glass.overlay)}>
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">System</p>
+            <pre className="font-mono text-[11px] whitespace-pre-wrap text-muted-foreground">{promptData.system}</pre>
+          </div>
+          <div className={cn("rounded-2xl p-4", glass.overlay)}>
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">User Template</p>
+            <pre className="font-mono text-[11px] whitespace-pre-wrap text-muted-foreground">{promptData.user_template}</pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Result Tab ---
+
+function tryPrettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function highlightHtml(html: string) {
+  // Tokenize HTML into tags and text segments
+  const parts: React.ReactNode[] = [];
+  const tagRegex = /(<\/?[\w-]+)((?:\s+[\w-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?)*)\s*(\/?>)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRegex.exec(html)) !== null) {
+    // Text before this tag
+    if (match.index > lastIndex) {
+      parts.push(html.slice(lastIndex, match.index));
+    }
+
+    const [, tagName, attrs, close] = match;
+    const attrParts: React.ReactNode[] = [];
+
+    if (attrs) {
+      const attrRegex = /([\w-]+)(\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?/g;
+      let attrMatch: RegExpExecArray | null;
+      while ((attrMatch = attrRegex.exec(attrs)) !== null) {
+        const [, name, valueWithEq] = attrMatch;
+        attrParts.push(" ");
+        attrParts.push(<span key={`a-${match.index}-${attrMatch.index}`} className="text-amber-600 dark:text-amber-400">{name}</span>);
+        if (valueWithEq) {
+          const eqIdx = valueWithEq.indexOf("=");
+          const eq = valueWithEq.slice(0, eqIdx + 1);
+          const val = valueWithEq.slice(eqIdx + 1);
+          attrParts.push(eq);
+          attrParts.push(<span key={`v-${match.index}-${attrMatch.index}`} className="text-emerald-600 dark:text-emerald-400">{val}</span>);
+        }
+      }
+    }
+
+    parts.push(
+      <span key={`t-${match.index}`}>
+        <span className="text-rose-600 dark:text-rose-400">{tagName}</span>
+        {attrParts}
+        <span className="text-rose-600 dark:text-rose-400">{close}</span>
+      </span>
+    );
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text
+  if (lastIndex < html.length) {
+    parts.push(html.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+function SkillResultTab({
+  execution,
+  viewingExecution,
+  skillName,
+  onRerun,
+  outputFormat,
+}: {
+  execution: ReturnType<typeof useSkillExecution>;
+  viewingExecution: SkillExecution | null;
+  skillName: string;
+  onRerun: () => void;
+  outputFormat?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  // Determine what to show: saved execution or live stream
+  const isLive = viewingExecution === null;
+  const resultText = isLive ? execution.result : viewingExecution?.result || "";
+  const isRunning = isLive && execution.state === "running";
+  const isDone = isLive ? execution.state === "done" : viewingExecution?.status === "completed";
+  const errorMsg = isLive ? execution.error : viewingExecution?.error;
+  const contentWarning = isLive ? execution.contentWarning : null;
+
+  const handleCopy = async () => {
+    if (!resultText) return;
+    await navigator.clipboard.writeText(resultText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Content warning */}
+      {contentWarning === "summary_only" && (
+        <div className={cn(
+          "flex items-center gap-2.5 p-3 rounded-2xl text-xs",
+          glass.card,
+          "border-l-2 border-amber-500"
+        )}>
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+          <span className="text-amber-700 dark:text-amber-400">
+            Only summary available — result may be limited.
+          </span>
+        </div>
+      )}
+
+      {/* Streaming indicator */}
+      {isRunning && !resultText && (
+        <div className="flex items-center gap-3 py-6 justify-center">
+          <div className="flex items-center gap-1">
+            <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "0ms" }} />
+            <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "150ms" }} />
+            <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" style={{ animationDelay: "300ms" }} />
+          </div>
+          <span className="text-sm text-muted-foreground">Generating {skillName.toLowerCase()}...</span>
+        </div>
+      )}
+
+      {/* Error */}
+      {errorMsg && (
+        <div className="flex items-center gap-2 p-3 rounded-2xl bg-red-500/10 dark:bg-red-500/15 border border-red-500/20 dark:border-red-500/25 text-xs text-red-700 dark:text-red-400">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          {errorMsg}
+        </div>
+      )}
+
+      {/* Result */}
+      {resultText && (
+        <div className={cn("rounded-2xl p-4", glass.card)}>
+          {(!outputFormat || outputFormat === "markdown") ? (
+            <div className="chat-prose text-sm">
+              <ReactMarkdown>{resultText}</ReactMarkdown>
+              {isRunning && (
+                <span className="inline-block w-2 h-4 ml-0.5 bg-current animate-pulse" />
+              )}
+            </div>
+          ) : outputFormat === "json" ? (
+            <pre className="text-sm font-mono whitespace-pre-wrap break-words overflow-x-auto">
+              <code>{tryPrettyJson(resultText)}</code>
+              {isRunning && (
+                <span className="inline-block w-2 h-4 ml-0.5 bg-current animate-pulse" />
+              )}
+            </pre>
+          ) : outputFormat === "html" ? (
+            <pre className="text-sm font-mono whitespace-pre-wrap break-words overflow-x-auto">
+              <code>{highlightHtml(resultText)}</code>
+              {isRunning && (
+                <span className="inline-block w-2 h-4 ml-0.5 bg-current animate-pulse" />
+              )}
+            </pre>
+          ) : (
+            <div className="text-sm whitespace-pre-wrap">
+              {resultText}
+              {isRunning && (
+                <span className="inline-block w-2 h-4 ml-0.5 bg-current animate-pulse" />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {isDone && resultText && (
+        <div className={cn("flex items-center gap-2 p-3 rounded-2xl", glass.overlay)}>
+          <button
+            onClick={handleCopy}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-xl transition-all duration-200",
+              glass.card,
+              "hover:shadow-md hover:scale-[1.02]"
+            )}
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-primary" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                Copy
+              </>
+            )}
+          </button>
+          <button
+            onClick={onRerun}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-xl transition-all duration-200",
+              glass.card,
+              "hover:shadow-md hover:scale-[1.02]"
+            )}
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Rerun
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- History Tab ---
+
+function SkillHistoryTab({
+  executions,
+  formatDate,
+  onView,
+}: {
+  executions: SkillExecution[];
+  formatDate: (date: string) => string;
+  onView: (execution: SkillExecution) => void;
+}) {
+  if (executions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+        <Clock className="h-8 w-8 mb-2 opacity-30" />
+        <p className="text-sm">No executions yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2.5">
+      {executions.map((ex, index) => (
+        <button
+          key={ex.id}
+          onClick={() => onView(ex)}
+          className={cn(
+            "w-full text-left p-3.5 rounded-2xl transition-all duration-200 animate-fade-in-up",
+            glass.base,
+            glass.hover
+          )}
+          style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-lg leading-none">
+              {ex.skill_logo ? (
+                <img src={ex.skill_logo} alt="" className="h-5 w-5 rounded object-cover" />
+              ) : (
+                ex.skill_icon
+              )}
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium truncate">{ex.skill_name}</div>
+              <div className="text-xs text-muted-foreground flex items-center gap-1.5 mt-0.5">
+                <Clock className="h-3 w-3" />
+                {ex.created_at ? formatDate(ex.created_at) : "—"}
+              </div>
+            </div>
+            <StatusBadge status={ex.status} />
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// --- Status Badge ---
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "completed") {
+    return (
+      <span className={cn(chips.base, "bg-primary/10 text-primary")}>
+        Done
+      </span>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <span className={cn(chips.base, "bg-red-500/10 text-red-700 dark:text-red-400")}>
+        Failed
+      </span>
+    );
+  }
+  if (status === "running") {
+    return (
+      <span className={cn(chips.base, "bg-blue-500/10 text-blue-500 animate-pulse")}>
+        Running
+      </span>
+    );
+  }
+  return null;
+}
+
+// --- Skill Results Section (for MemoryDetailPanel) ---
+
+export function SkillResultsSection({
+  memoryId,
+  formatDate,
+  onViewExecution,
+}: {
+  memoryId: number;
+  formatDate: (date: string) => string;
+  onViewExecution: (executionId: number) => void;
+}) {
+  const { executions, isLoading } = useSkillHistory(memoryId);
+
+  if (isLoading || executions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 pt-4 border-t">
+      <div className="flex items-center gap-2">
+        <Zap className="h-4 w-4 text-primary" />
+        <span className="text-sm font-medium text-muted-foreground">Skill Results</span>
+        <span className={cn(chips.base, chips.primary)}>{executions.length}</span>
+      </div>
+      <div className="space-y-2">
+        {executions.map((ex, index) => (
+          <button
+            key={ex.id}
+            onClick={() => onViewExecution(ex.id)}
+            className={cn(
+              "w-full flex items-center gap-3 p-3 rounded-2xl text-left transition-all duration-200 animate-fade-in-up",
+              glass.base,
+              glass.hover
+            )}
+            style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
+          >
+            <span className="text-base leading-none">
+              {ex.skill_logo ? (
+                <img src={ex.skill_logo} alt="" className="h-4 w-4 rounded object-cover" />
+              ) : (
+                ex.skill_icon
+              )}
+            </span>
+            <span className="text-xs flex-1 truncate font-medium">{ex.skill_name}</span>
+            <span className="text-[10px] text-muted-foreground">
+              {ex.created_at ? formatDate(ex.created_at) : ""}
+            </span>
+            <Eye className="h-3 w-3 text-muted-foreground" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/SkillTestRunner.tsx
+++ b/app/src/components/SkillTestRunner.tsx
@@ -1,0 +1,736 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import {
+  Play,
+  Search,
+  Loader2,
+  AlertCircle,
+  Copy,
+  Check,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { glass, chips } from "@/lib/design-tokens";
+import { apiFetch } from "@/lib/api";
+import { useSkillTest } from "@/hooks/useSkills";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SkillParameterDef {
+  id: string;
+  label: string;
+  description: string;
+  type: "select" | "boolean" | "string" | "number";
+  options: string[];
+  default: string;
+}
+
+interface SkillTestRunnerProps {
+  formState: {
+    name: string;
+    description: string;
+    icon: string;
+    category: string;
+    tags: string[];
+    input_accepts: string[] | null;
+    parameters: SkillParameterDef[];
+    prompt_system: string;
+    prompt_user_template: string;
+    output_format: string;
+  };
+}
+
+interface MemoryItem {
+  id: number;
+  title: string;
+  type: string;
+  created_at: string;
+}
+
+interface MemoryListResponse {
+  memories: MemoryItem[];
+  total: number;
+  has_more: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Memory Selector
+// ---------------------------------------------------------------------------
+
+function MemorySelector({
+  selectedMemory,
+  onSelect,
+}: {
+  selectedMemory: MemoryItem | null;
+  onSelect: (memory: MemoryItem | null) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [memories, setMemories] = useState<MemoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Fetch default memories on mount
+  useEffect(() => {
+    fetchMemories();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const fetchMemories = useCallback(async (searchQuery?: string) => {
+    setIsLoading(true);
+    try {
+      const endpoint = searchQuery
+        ? `/api/memories/search?q=${encodeURIComponent(searchQuery)}&limit=20`
+        : `/api/memories?limit=20&offset=0`;
+      const res = await apiFetch(endpoint);
+      if (!res.ok) throw new Error("Failed to fetch memories");
+      const data: MemoryListResponse = await res.json();
+      setMemories(data.memories);
+    } catch {
+      setMemories([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    setIsOpen(true);
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchMemories(value || undefined);
+    }, 300);
+  };
+
+  const handleSelect = (memory: MemoryItem) => {
+    onSelect(memory);
+    setQuery(memory.title || `Memory #${memory.id}`);
+    setIsOpen(false);
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    setQuery("");
+    fetchMemories();
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground mb-2 block">
+        Target Memory
+      </label>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+        <Input
+          value={query}
+          onChange={(e) => handleQueryChange(e.target.value)}
+          onFocus={() => setIsOpen(true)}
+          placeholder="Search memories..."
+          className={cn(
+            "pl-9 pr-3 rounded-xl",
+            "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+            "border-white/40 dark:border-white/[0.06]",
+            "focus-visible:ring-primary/30"
+          )}
+        />
+        {isLoading && (
+          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        )}
+      </div>
+
+      {/* Selected indicator */}
+      {selectedMemory && (
+        <div
+          className={cn(
+            "mt-2 flex items-center gap-2 px-3 py-2 rounded-xl text-sm",
+            glass.card
+          )}
+        >
+          <div className="flex-1 min-w-0">
+            <span className="font-medium truncate block">
+              {selectedMemory.title || `Memory #${selectedMemory.id}`}
+            </span>
+          </div>
+          <MemoryTypeBadge type={selectedMemory.type} />
+          <button
+            onClick={handleClear}
+            className="text-muted-foreground hover:text-foreground transition-colors text-xs"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      {/* Dropdown */}
+      {isOpen && memories.length > 0 && (
+        <div
+          className={cn(
+            "absolute z-50 mt-1.5 w-full max-h-60 overflow-y-auto rounded-xl animate-scale-in",
+            "bg-white dark:bg-neutral-900 border border-white/50 dark:border-white/[0.08] shadow-large"
+          )}
+        >
+          {memories.map((memory) => (
+            <button
+              key={memory.id}
+              onClick={() => handleSelect(memory)}
+              className={cn(
+                "w-full text-left px-3 py-2.5 flex items-center gap-2.5 transition-all duration-150",
+                "hover:bg-primary/5 dark:hover:bg-primary/10 hover:pl-4",
+                "first:rounded-t-xl last:rounded-b-xl",
+                selectedMemory?.id === memory.id && "bg-primary/5"
+              )}
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">
+                  {memory.title || `Memory #${memory.id}`}
+                </p>
+              </div>
+              <MemoryTypeBadge type={memory.type} />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isOpen && !isLoading && memories.length === 0 && query && (
+        <div
+          className={cn(
+            "absolute z-50 mt-1 w-full rounded-xl shadow-lg p-4 text-center",
+            "bg-white dark:bg-neutral-900 border border-white/50 dark:border-white/[0.08]"
+          )}
+        >
+          <p className="text-sm text-muted-foreground">No memories found</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Memory Type Badge
+// ---------------------------------------------------------------------------
+
+function MemoryTypeBadge({ type }: { type: string }) {
+  const label =
+    type === "voice_memo"
+      ? "Voice"
+      : type.charAt(0).toUpperCase() + type.slice(1);
+
+  return (
+    <span
+      className={cn(
+        chips.base,
+        chips.glass,
+        "text-[10px] flex-shrink-0"
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Parameter Controls
+// ---------------------------------------------------------------------------
+
+function ParameterControls({
+  parameters,
+  values,
+  onChange,
+}: {
+  parameters: SkillParameterDef[];
+  values: Record<string, unknown>;
+  onChange: (values: Record<string, unknown>) => void;
+}) {
+  if (parameters.length === 0) return null;
+
+  const updateValue = (id: string, value: unknown) => {
+    onChange({ ...values, [id]: value });
+  };
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        Parameters
+      </h4>
+      {parameters.map((param) => (
+        <div
+          key={param.id}
+          className={cn("p-3 rounded-xl space-y-2", glass.card)}
+        >
+          <div>
+            <label className="text-sm font-medium">{param.label}</label>
+            {param.description && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {param.description}
+              </p>
+            )}
+          </div>
+
+          {/* Select: chip buttons */}
+          {param.type === "select" && param.options && (
+            <div className="flex flex-wrap gap-1.5">
+              {param.options.map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => updateValue(param.id, opt)}
+                  className={cn(
+                    chips.base,
+                    "transition-all duration-200",
+                    values[param.id] === opt
+                      ? "bg-primary text-primary-foreground shadow-sm"
+                      : cn(chips.glass, "hover:bg-primary/10")
+                  )}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Boolean: Yes/No toggle */}
+          {param.type === "boolean" && (
+            <div className="flex gap-1.5">
+              {(["Yes", "No"] as const).map((label) => {
+                const val = label === "Yes";
+                return (
+                  <button
+                    key={label}
+                    onClick={() => updateValue(param.id, val)}
+                    className={cn(
+                      chips.base,
+                      "transition-all duration-200",
+                      values[param.id] === val
+                        ? "bg-primary text-primary-foreground shadow-sm"
+                        : cn(chips.glass, "hover:bg-primary/10")
+                    )}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {/* String input */}
+          {param.type === "string" && (
+            <input
+              type="text"
+              value={(values[param.id] as string) || ""}
+              onChange={(e) => updateValue(param.id, e.target.value)}
+              className={cn(
+                "w-full px-3 py-1.5 text-sm rounded-xl border border-white/40 dark:border-white/[0.06]",
+                "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+                "focus:outline-none focus:ring-1 focus:ring-primary/30"
+              )}
+            />
+          )}
+
+          {/* Number input */}
+          {param.type === "number" && (
+            <input
+              type="number"
+              value={(values[param.id] as number) ?? ""}
+              onChange={(e) =>
+                updateValue(param.id, parseFloat(e.target.value) || 0)
+              }
+              className={cn(
+                "w-full px-3 py-1.5 text-sm rounded-xl border border-white/40 dark:border-white/[0.06]",
+                "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+                "focus:outline-none focus:ring-1 focus:ring-primary/30"
+              )}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result Area
+// ---------------------------------------------------------------------------
+
+function tryPrettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function highlightHtml(html: string) {
+  const parts: React.ReactNode[] = [];
+  const tagRegex = /(<\/?[\w-]+)((?:\s+[\w-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?)*)\s*(\/?>)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRegex.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(html.slice(lastIndex, match.index));
+    }
+    const [, tagName, attrs, close] = match;
+    const attrParts: React.ReactNode[] = [];
+    if (attrs) {
+      const attrRegex = /([\w-]+)(\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*))?/g;
+      let attrMatch: RegExpExecArray | null;
+      while ((attrMatch = attrRegex.exec(attrs)) !== null) {
+        const [, name, valueWithEq] = attrMatch;
+        attrParts.push(" ");
+        attrParts.push(<span key={`a-${match.index}-${attrMatch.index}`} className="text-amber-600 dark:text-amber-400">{name}</span>);
+        if (valueWithEq) {
+          const eqIdx = valueWithEq.indexOf("=");
+          const eq = valueWithEq.slice(0, eqIdx + 1);
+          const val = valueWithEq.slice(eqIdx + 1);
+          attrParts.push(eq);
+          attrParts.push(<span key={`v-${match.index}-${attrMatch.index}`} className="text-emerald-600 dark:text-emerald-400">{val}</span>);
+        }
+      }
+    }
+    parts.push(
+      <span key={`t-${match.index}`}>
+        <span className="text-rose-600 dark:text-rose-400">{tagName}</span>
+        {attrParts}
+        <span className="text-rose-600 dark:text-rose-400">{close}</span>
+      </span>
+    );
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < html.length) {
+    parts.push(html.slice(lastIndex));
+  }
+  return parts;
+}
+
+function TestResultArea({
+  state,
+  result,
+  error,
+  contentWarning,
+  outputFormat,
+}: {
+  state: "idle" | "running" | "done" | "error";
+  result: string;
+  error: string | null;
+  contentWarning: string | null;
+  outputFormat?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result);
+      setCopied(true);
+      toast.success("Copied to clipboard");
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Failed to copy");
+    }
+  };
+
+  // Idle: hint text
+  if (state === "idle") {
+    return (
+      <div className="flex flex-col items-center justify-center py-5 text-muted-foreground">
+        <Play className="h-6 w-6 mb-2 opacity-20" />
+        <p className="text-xs">
+          Select a memory and click Test Run to preview the output.
+        </p>
+      </div>
+    );
+  }
+
+  // Error
+  if (state === "error") {
+    return (
+      <div
+        className={cn(
+          "flex items-start gap-2.5 p-4 rounded-2xl text-sm",
+          "bg-red-500/10 dark:bg-red-500/15 border border-red-500/20 dark:border-red-500/25"
+        )}
+      >
+        <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
+        <span className="text-red-700 dark:text-red-400">{error || "An error occurred"}</span>
+      </div>
+    );
+  }
+
+  // Running or Done
+  return (
+    <div className="space-y-3">
+      {/* Content warning */}
+      {contentWarning === "summary_only" && (
+        <div
+          className={cn(
+            "flex items-center gap-2.5 p-3 rounded-2xl text-xs",
+            glass.card,
+            "border-l-2 border-amber-500"
+          )}
+        >
+          <AlertCircle className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+          <span className="text-amber-700 dark:text-amber-400">
+            Only summary available for this memory — result may be limited.
+          </span>
+        </div>
+      )}
+
+      {/* Streaming indicator before first token */}
+      {state === "running" && !result && (
+        <div className={cn("flex items-center gap-3 py-5 justify-center rounded-2xl", glass.card)}>
+          <div className="flex items-center gap-1">
+            <span
+              className="h-2 w-2 rounded-full bg-primary animate-pulse"
+              style={{ animationDelay: "0ms" }}
+            />
+            <span
+              className="h-2 w-2 rounded-full bg-primary animate-pulse"
+              style={{ animationDelay: "150ms" }}
+            />
+            <span
+              className="h-2 w-2 rounded-full bg-primary animate-pulse"
+              style={{ animationDelay: "300ms" }}
+            />
+          </div>
+          <span className="text-sm text-muted-foreground/70">
+            Generating test output...
+          </span>
+        </div>
+      )}
+
+      {/* Result */}
+      {result && (
+        <div className={cn("rounded-2xl p-4 border-l-2 border-primary/30 animate-fade-in-up", glass.card)}>
+          {(!outputFormat || outputFormat === "markdown") ? (
+            <div className="chat-prose text-sm">
+              <ReactMarkdown>{result}</ReactMarkdown>
+              {state === "running" && (
+                <span className="inline-block w-0.5 h-4 ml-0.5 bg-primary animate-pulse align-text-bottom" />
+              )}
+            </div>
+          ) : outputFormat === "json" ? (
+            <pre className="text-sm font-mono whitespace-pre-wrap break-words overflow-x-auto">
+              <code>{tryPrettyJson(result)}</code>
+              {state === "running" && (
+                <span className="inline-block w-0.5 h-4 ml-0.5 bg-primary animate-pulse align-text-bottom" />
+              )}
+            </pre>
+          ) : outputFormat === "html" ? (
+            <pre className="text-sm font-mono whitespace-pre-wrap break-words overflow-x-auto">
+              <code>{highlightHtml(result)}</code>
+              {state === "running" && (
+                <span className="inline-block w-0.5 h-4 ml-0.5 bg-primary animate-pulse align-text-bottom" />
+              )}
+            </pre>
+          ) : (
+            <div className="text-sm whitespace-pre-wrap">
+              {result}
+              {state === "running" && (
+                <span className="inline-block w-0.5 h-4 ml-0.5 bg-primary animate-pulse align-text-bottom" />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Copy button when done */}
+      {state === "done" && result && (
+        <div className={cn("flex items-center gap-2 p-3 rounded-2xl animate-fade-in-up", glass.overlay)}>
+          <button
+            onClick={handleCopy}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-xl transition-all duration-200",
+              glass.card,
+              "hover:shadow-md hover:scale-[1.02] hover:text-primary active:scale-95"
+            )}
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-primary" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                Copy
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export default function SkillTestRunner({ formState }: SkillTestRunnerProps) {
+  const [selectedMemory, setSelectedMemory] = useState<MemoryItem | null>(null);
+  const [paramValues, setParamValues] = useState<Record<string, unknown>>({});
+
+  const { state, result, error, contentWarning, execute, reset } =
+    useSkillTest();
+
+  // Initialize parameter defaults when formState.parameters changes
+  useEffect(() => {
+    const defaults: Record<string, unknown> = {};
+    for (const p of formState.parameters) {
+      if (p.type === "boolean") {
+        defaults[p.id] = p.default === "true" || p.default === "yes";
+      } else if (p.type === "number") {
+        defaults[p.id] = parseFloat(p.default) || 0;
+      } else {
+        defaults[p.id] = p.default || "";
+      }
+    }
+    setParamValues(defaults);
+  }, [formState.parameters]);
+
+  // Reset test result when prompts change
+  useEffect(() => {
+    if (state === "done" || state === "error") {
+      reset();
+    }
+    // Only reset when prompts change, not when state changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formState.prompt_system, formState.prompt_user_template]);
+
+  const canRun =
+    selectedMemory !== null &&
+    formState.prompt_system.trim() !== "" &&
+    formState.prompt_user_template.trim() !== "" &&
+    state !== "running";
+
+  const handleTestRun = async () => {
+    if (!selectedMemory) return;
+
+    // Map parameters to API format
+    const apiParameters = formState.parameters.map((p) => ({
+      id: p.id,
+      label: p.label,
+      description: p.description,
+      type: p.type,
+      options: p.type === "select" ? p.options : undefined,
+      default: p.default as unknown,
+    }));
+
+    await execute({
+      memory_id: selectedMemory.id,
+      prompt_system: formState.prompt_system,
+      prompt_user_template: formState.prompt_user_template,
+      parameters: apiParameters.length > 0 ? apiParameters : null,
+      parameter_values: paramValues,
+      input_accepts: formState.input_accepts,
+      output_format: formState.output_format,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Section header */}
+      <div className="flex items-start gap-3">
+        <div className="h-8 w-8 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <Play className="h-4 w-4 text-emerald-500" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium">Test Run</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Preview the skill output against a real memory.
+          </p>
+        </div>
+      </div>
+
+      {/* Memory Selector */}
+      <MemorySelector
+        selectedMemory={selectedMemory}
+        onSelect={setSelectedMemory}
+      />
+
+      {/* Parameter Controls */}
+      <ParameterControls
+        parameters={formState.parameters}
+        values={paramValues}
+        onChange={setParamValues}
+      />
+
+      {/* Test Run Button */}
+      <Button
+        onClick={handleTestRun}
+        disabled={!canRun}
+        className={cn(
+          "w-full h-11 gap-2 transition-all duration-200",
+          canRun
+            ? "bg-primary hover:bg-primary/90 shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30 hover:scale-[1.005]"
+            : "opacity-60"
+        )}
+      >
+        {state === "running" ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Running...
+          </>
+        ) : (
+          <>
+            <Play className="h-4 w-4" />
+            Test Run
+          </>
+        )}
+      </Button>
+
+      {/* Validation hints */}
+      {!canRun && state !== "running" && (
+        <div className="space-y-1">
+          {!selectedMemory && (
+            <p className="text-[11px] text-muted-foreground/60 flex items-center gap-1.5">
+              <AlertCircle className="h-3 w-3" />
+              Select a memory to test against
+            </p>
+          )}
+          {formState.prompt_system.trim() === "" && (
+            <p className="text-[11px] text-muted-foreground/60 flex items-center gap-1.5">
+              <AlertCircle className="h-3 w-3" />
+              System prompt is empty
+            </p>
+          )}
+          {formState.prompt_user_template.trim() === "" && (
+            <p className="text-[11px] text-muted-foreground/60 flex items-center gap-1.5">
+              <AlertCircle className="h-3 w-3" />
+              User template is empty
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Result Area */}
+      <TestResultArea
+        state={state}
+        result={result}
+        error={error}
+        contentWarning={contentWarning}
+        outputFormat={formState.output_format}
+      />
+    </div>
+  );
+}

--- a/app/src/components/TriggerEditor.tsx
+++ b/app/src/components/TriggerEditor.tsx
@@ -1,0 +1,382 @@
+import { useState, useEffect, useCallback } from "react";
+import { Plus, X, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { glass } from "@/lib/design-tokens";
+import TriggerPreview from "./TriggerPreview";
+import type {
+  SkillTrigger,
+  TriggerRule,
+  TriggerConditions,
+  TriggerCreateRequest,
+  TriggerUpdateRequest,
+} from "@/lib/api";
+
+const FIELDS = [
+  { value: "type", label: "Type" },
+  { value: "tags", label: "Tags" },
+  { value: "title", label: "Title" },
+  { value: "url", label: "URL" },
+  { value: "content_length", label: "Content Length" },
+  { value: "has_transcript", label: "Has Transcript" },
+  { value: "media_source", label: "Media Source" },
+];
+
+const TEXT_OPERATORS = [
+  { value: "equals", label: "equals" },
+  { value: "not_equals", label: "not equals" },
+  { value: "contains", label: "contains" },
+  { value: "not_contains", label: "not contains" },
+  { value: "starts_with", label: "starts with" },
+  { value: "is_empty", label: "is empty" },
+  { value: "is_not_empty", label: "is not empty" },
+];
+
+const NUMERIC_OPERATORS = [
+  { value: "equals", label: "equals" },
+  { value: "not_equals", label: "not equals" },
+  { value: "greater_than", label: "greater than" },
+  { value: "less_than", label: "less than" },
+];
+
+const BOOLEAN_OPERATORS = [
+  { value: "equals", label: "equals" },
+];
+
+function getOperatorsForField(field: string) {
+  if (field === "content_length") return NUMERIC_OPERATORS;
+  if (field === "has_transcript") return BOOLEAN_OPERATORS;
+  return TEXT_OPERATORS;
+}
+
+function isValueless(op: string): boolean {
+  return op === "is_empty" || op === "is_not_empty";
+}
+
+const TYPE_VALUES = ["web", "note", "voice_memo", "audio", "video", "document"];
+const BOOLEAN_VALUES = ["true", "false"];
+const MEDIA_SOURCE_VALUES = ["recording", "upload"];
+
+function getPresetValues(field: string): string[] | null {
+  if (field === "type") return TYPE_VALUES;
+  if (field === "has_transcript") return BOOLEAN_VALUES;
+  if (field === "media_source") return MEDIA_SOURCE_VALUES;
+  return null;
+}
+
+interface TriggerEditorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: TriggerCreateRequest | TriggerUpdateRequest) => Promise<void>;
+  trigger?: SkillTrigger | null;
+  isSaving?: boolean;
+}
+
+const emptyRule: TriggerRule = { field: "type", op: "equals", value: "" };
+
+const selectClass = cn(
+  "h-9 rounded-lg border border-white/40 dark:border-white/[0.06]",
+  "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm",
+  "px-2.5 text-sm",
+  "focus:outline-none focus:ring-1 focus:ring-ring",
+  "min-w-0 flex-1"
+);
+
+export default function TriggerEditor({
+  isOpen,
+  onClose,
+  onSave,
+  trigger,
+  isSaving = false,
+}: TriggerEditorProps) {
+  const isEditMode = !!trigger;
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [operator, setOperator] = useState<"AND" | "OR">("AND");
+  const [rules, setRules] = useState<TriggerRule[]>([{ ...emptyRule }]);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (trigger) {
+        setName(trigger.name);
+        setDescription(trigger.description || "");
+        setOperator(trigger.conditions.operator);
+        setRules(
+          trigger.conditions.rules.length
+            ? trigger.conditions.rules.map((r) => ({ ...r }))
+            : [{ ...emptyRule }]
+        );
+      } else {
+        setName("");
+        setDescription("");
+        setOperator("AND");
+        setRules([{ ...emptyRule }]);
+      }
+    }
+  }, [isOpen, trigger]);
+
+  const addRule = useCallback(() => {
+    setRules((prev) => [...prev, { ...emptyRule }]);
+  }, []);
+
+  const removeRule = useCallback((index: number) => {
+    setRules((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
+
+  const updateRule = useCallback(
+    (index: number, patch: Partial<TriggerRule>) => {
+      setRules((prev) =>
+        prev.map((r, i) => {
+          if (i !== index) return r;
+          const updated = { ...r, ...patch };
+          if (patch.field && patch.field !== r.field) {
+            const ops = getOperatorsForField(patch.field);
+            updated.op = ops[0].value;
+            updated.value = "";
+          }
+          if (patch.op && isValueless(patch.op)) {
+            updated.value = "";
+          }
+          return updated;
+        })
+      );
+    },
+    []
+  );
+
+  const conditions: TriggerConditions | null =
+    rules.length > 0 && rules.some((r) => r.field)
+      ? { operator, rules }
+      : null;
+
+  const canSave =
+    name.trim().length > 0 &&
+    rules.length > 0 &&
+    rules.every(
+      (r) => r.field && r.op && (isValueless(r.op) || String(r.value).length > 0)
+    );
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    await onSave({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      conditions: { operator, rules },
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+            className="max-w-lg max-h-[85vh] overflow-y-auto"
+            onPointerDownOutside={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {isEditMode ? "Edit Trigger" : "New Trigger"}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditMode
+              ? "Modify when this skill runs automatically."
+              : "Define conditions for automatic skill execution on memory save."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Name */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+              Name
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Auto-summarize web articles"
+              className="text-sm focus:border-l-2 focus:border-l-primary"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
+              Description
+              <span className="text-muted-foreground/40 ml-1">(optional)</span>
+            </label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="When should this trigger fire?"
+              className="text-sm focus:border-l-2 focus:border-l-primary"
+            />
+          </div>
+
+          {/* Conditions */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <label className="text-xs font-medium text-muted-foreground">
+                Conditions
+              </label>
+              {rules.length > 1 && (
+                <div className={cn("inline-flex rounded-full p-0.5", glass.card)}>
+                  {(["AND", "OR"] as const).map((op) => (
+                    <button
+                      key={op}
+                      onClick={() => setOperator(op)}
+                      className={cn(
+                        "px-3 py-1 rounded-full text-[10px] font-semibold tracking-wide transition-all duration-200",
+                        operator === op
+                          ? "bg-primary/15 text-primary shadow-sm"
+                          : "text-muted-foreground/40 hover:text-muted-foreground/60"
+                      )}
+                    >
+                      {op}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-3">
+              {rules.map((rule, index) => {
+                const ops = getOperatorsForField(rule.field);
+                const presets = getPresetValues(rule.field);
+                const valueless = isValueless(rule.op);
+
+                return (
+                  <div key={index}>
+                    {/* AND/OR divider between rules */}
+                    {index > 0 && (
+                      <div className="flex items-center gap-2 py-0">
+                        <div className="flex-1 h-px bg-muted-foreground/10" />
+                        <span className="text-[9px] font-semibold text-muted-foreground/30 uppercase tracking-widest">
+                          {operator}
+                        </span>
+                        <div className="flex-1 h-px bg-muted-foreground/10" />
+                      </div>
+                    )}
+
+                    {/* Rule card */}
+                    <div className={cn("relative rounded-lg p-3", glass.overlay)}>
+                      {/* Remove button */}
+                      {rules.length > 1 && (
+                        <button
+                          onClick={() => removeRule(index)}
+                          className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full bg-muted/80 dark:bg-muted/40 flex items-center justify-center text-muted-foreground/50 hover:text-red-500 hover:bg-red-500/10 transition-all duration-200 z-10"
+                        >
+                          <X className="h-2.5 w-2.5" />
+                        </button>
+                      )}
+
+                      <div className="flex flex-wrap gap-8">
+                        {/* Field */}
+                        <div className="flex-1 min-w-[100px]">
+                          <span className="text-[9px] uppercase tracking-wider text-muted-foreground/30 font-medium block mb-1">
+                            Field
+                          </span>
+                          <select
+                            value={rule.field}
+                            onChange={(e) => updateRule(index, { field: e.target.value })}
+                            className={selectClass}
+                          >
+                            {FIELDS.map((f) => (
+                              <option key={f.value} value={f.value}>{f.label}</option>
+                            ))}
+                          </select>
+                        </div>
+
+                        {/* Operator */}
+                        <div className="flex-1 min-w-[100px]">
+                          <span className="text-[9px] uppercase tracking-wider text-muted-foreground/30 font-medium block mb-1">
+                            Operator
+                          </span>
+                          <select
+                            value={rule.op}
+                            onChange={(e) => updateRule(index, { op: e.target.value })}
+                            className={selectClass}
+                          >
+                            {ops.map((o) => (
+                              <option key={o.value} value={o.value}>{o.label}</option>
+                            ))}
+                          </select>
+                        </div>
+
+                        {/* Value */}
+                        {!valueless && (
+                          <div className="flex-1 min-w-[100px]">
+                            <span className="text-[9px] uppercase tracking-wider text-muted-foreground/30 font-medium block mb-1">
+                              Value
+                            </span>
+                            {presets ? (
+                              <select
+                                value={String(rule.value)}
+                                onChange={(e) => updateRule(index, { value: e.target.value })}
+                                className={selectClass}
+                              >
+                                <option value="">Select...</option>
+                                {presets.map((v) => (
+                                  <option key={v} value={v}>{v}</option>
+                                ))}
+                              </select>
+                            ) : (
+                              <Input
+                                value={String(rule.value)}
+                                onChange={(e) =>
+                                  updateRule(index, {
+                                    value: rule.field === "content_length" ? Number(e.target.value) || "" : e.target.value,
+                                  })
+                                }
+                                placeholder="value"
+                                className="h-9 text-sm flex-1 min-w-0"
+                                type={rule.field === "content_length" ? "number" : "text"}
+                              />
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+
+              {/* Add condition button */}
+              <button
+                onClick={addRule}
+                className="w-full mt-2 flex items-center justify-center gap-1.5 py-2.5 rounded-lg border-2 border-dashed border-muted-foreground/15 hover:border-primary/30 text-xs text-muted-foreground/40 hover:text-primary/70 transition-all duration-200"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add condition
+              </button>
+            </div>
+          </div>
+
+          {/* Preview */}
+          <TriggerPreview conditions={conditions} />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave || isSaving}>
+            {isSaving && <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />}
+            {isEditMode ? "Save Changes" : "Create Trigger"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/TriggerList.tsx
+++ b/app/src/components/TriggerList.tsx
@@ -1,0 +1,145 @@
+import {
+  ZapOff,
+  Pencil,
+  Trash2,
+  Activity,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { glass, chips } from "@/lib/design-tokens";
+import type { SkillTrigger } from "@/lib/api";
+
+interface TriggerListProps {
+  triggers: SkillTrigger[];
+  onEdit: (trigger: SkillTrigger) => void;
+  onDelete: (triggerId: number) => void;
+  onToggle: (triggerId: number, enabled: boolean) => void;
+}
+
+function formatConditionSummary(trigger: SkillTrigger): string {
+  const { conditions } = trigger;
+  if (!conditions.rules.length) return "No conditions";
+
+  const parts = conditions.rules.map((r) => {
+    const op = r.op.replace(/_/g, " ");
+    return `${r.field} ${op} ${String(r.value)}`;
+  });
+
+  if (parts.length === 1) return parts[0];
+  const join = conditions.operator === "AND" ? " & " : " | ";
+  return parts.join(join);
+}
+
+function formatRelativeDate(dateStr: string | null): string {
+  if (!dateStr) return "Never";
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return d.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit" });
+}
+
+export default function TriggerList({
+  triggers,
+  onEdit,
+  onDelete,
+  onToggle,
+}: TriggerListProps) {
+  if (!triggers.length) {
+    return (
+      <div className={cn("rounded-xl p-6 text-center", glass.card)}>
+        <div className="mx-auto mb-3 h-10 w-10 rounded-full border-2 border-dashed border-muted-foreground/20 flex items-center justify-center">
+          <ZapOff className="h-4 w-4 text-muted-foreground/30" />
+        </div>
+        <p className="text-sm text-muted-foreground/50">
+          No triggers yet. Add one to automate this skill.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("rounded-xl p-2 space-y-1", glass.card)}>
+      {triggers.map((trigger, index) => (
+        <div
+          key={trigger.id}
+          className={cn(
+            "group flex items-center gap-3 py-2.5 px-3 rounded-lg transition-all duration-200 animate-fade-in-up",
+            "hover:bg-white/30 dark:hover:bg-white/[0.03]",
+            !trigger.enabled && "opacity-50"
+          )}
+          style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
+        >
+          {/* Status dot */}
+          <button
+            onClick={() => onToggle(trigger.id, !trigger.enabled)}
+            className="flex-shrink-0 group/dot"
+            title={trigger.enabled ? "Disable trigger" : "Enable trigger"}
+          >
+            <div
+              className={cn(
+                "h-2.5 w-2.5 rounded-full transition-all duration-200",
+                trigger.enabled
+                  ? "bg-emerald-500 shadow-sm shadow-emerald-500/50 group-hover/dot:ring-2 group-hover/dot:ring-emerald-500/20"
+                  : "bg-muted-foreground/30 group-hover/dot:ring-2 group-hover/dot:ring-muted-foreground/10"
+              )}
+            />
+          </button>
+
+          {/* Info */}
+          <div className="flex-1 min-w-0">
+            <p
+              className={cn(
+                "text-sm font-medium truncate",
+                !trigger.enabled && "line-through text-muted-foreground/50"
+              )}
+            >
+              {trigger.name}
+            </p>
+            <p className="text-[10px] text-muted-foreground/50 truncate mt-0.5">
+              {formatConditionSummary(trigger)}
+            </p>
+          </div>
+
+          {/* Stats pill */}
+          <div className="flex items-center gap-1.5 rounded-full bg-white/30 dark:bg-white/[0.03] px-2 py-1 flex-shrink-0">
+            <Activity className="h-2.5 w-2.5 text-muted-foreground/40" />
+            <span className="text-[10px] text-muted-foreground/50 tabular-nums">
+              {trigger.execution_count}
+            </span>
+            <span className="text-[10px] text-muted-foreground/30">&middot;</span>
+            <span className="text-[10px] text-muted-foreground/40">
+              {formatRelativeDate(trigger.last_triggered_at)}
+            </span>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-primary"
+              onClick={() => onEdit(trigger)}
+            >
+              <Pencil className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-red-500"
+              onClick={() => onDelete(trigger.id)}
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/TriggerPreview.tsx
+++ b/app/src/components/TriggerPreview.tsx
@@ -1,0 +1,93 @@
+import { Loader2, Database, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { glass, memoryTypeColors, getMemoryTypeColor } from "@/lib/design-tokens";
+import { useTriggerPreview } from "@/hooks/useSkills";
+import type { TriggerConditions } from "@/lib/api";
+
+interface TriggerPreviewProps {
+  conditions: TriggerConditions | null;
+}
+
+export default function TriggerPreview({ conditions }: TriggerPreviewProps) {
+  const { preview, isLoading } = useTriggerPreview(conditions);
+
+  if (!conditions || !conditions.rules.length) return null;
+
+  const matchRatio =
+    preview && preview.total_memories > 0
+      ? preview.matching_count / preview.total_memories
+      : 0;
+
+  return (
+    <div className={cn("rounded-xl p-3 space-y-3", glass.overlay)}>
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Database className="h-3 w-3 text-muted-foreground/50" />
+        <span className="text-[10px] font-semibold text-muted-foreground/60 uppercase tracking-wider">
+          Preview
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          <div className="h-3 w-32 rounded-full bg-muted/40 animate-pulse" />
+          <div className="h-1 w-full rounded-full bg-muted/30 animate-pulse" />
+          <div className="h-3 w-24 rounded-full bg-muted/40 animate-pulse" />
+        </div>
+      ) : preview ? (
+        <>
+          {/* Count + ratio bar */}
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              <span className={cn("font-semibold", preview.matching_count > 0 ? "text-primary" : "text-muted-foreground/50")}>
+                {preview.matching_count}
+              </span>
+              <span className="text-muted-foreground/40"> of </span>
+              <span className="font-semibold text-foreground/70">
+                {preview.total_memories}
+              </span>
+              <span className="text-muted-foreground/40"> memories match</span>
+            </p>
+            <div className="h-1 w-full rounded-full bg-muted/30 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary/40 transition-all duration-500 ease-out"
+                style={{ width: `${Math.max(matchRatio * 100, preview.matching_count > 0 ? 2 : 0)}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Matching memories list */}
+          {preview.matching_memories.length > 0 && (
+            <div className="space-y-1 max-h-28 overflow-y-auto">
+              {preview.matching_memories.map((m) => {
+                const color = getMemoryTypeColor(m.type);
+                return (
+                  <div
+                    key={m.id}
+                    className="flex items-center gap-2 text-[11px] py-0.5"
+                  >
+                    <div className={cn("h-1.5 w-1.5 rounded-full flex-shrink-0", color.bg)} />
+                    <span className="truncate text-muted-foreground">
+                      {m.title || "Untitled"}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground/30 flex-shrink-0 ml-auto">
+                      {m.type}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Zero matches info */}
+          {preview.matching_count === 0 && (
+            <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/40">
+              <Info className="h-3 w-3" />
+              No memories match these conditions
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/contexts/ConversationContext.tsx
+++ b/app/src/contexts/ConversationContext.tsx
@@ -64,6 +64,7 @@ export function ConversationProvider({ children }: { children: ReactNode }) {
             ...m,
             timestamp: new Date(m.created_at || ""),
             sources: m.sources || [],
+            metadata: m.metadata || undefined,
           }))
         );
 

--- a/app/src/global.d.ts
+++ b/app/src/global.d.ts
@@ -39,6 +39,10 @@ declare global {
       removeVideoProcessListeners: () => void;
       // Document viewing
       openDocumentWithSystem: (documentId: number, filename: string) => Promise<{ success: boolean; error?: string }>;
+      // Skill file import/export
+      onImportSkillFile: (callback: (data: { filePath: string; content: string }) => void) => void;
+      removeImportSkillFileListener: () => void;
+      saveSkillFile: (content: string, suggestedName: string) => Promise<{ success: boolean; filePath?: string; error?: string }>;
     };
   }
 }

--- a/app/src/hooks/useMemoryEvents.ts
+++ b/app/src/hooks/useMemoryEvents.ts
@@ -8,6 +8,8 @@ export type MemoryEventType =
   | "memory_created"
   | "memory_updated"
   | "memory_deleted"
+  | "memory_processed"
+  | "skill_executed"
   | "conversation_created"
   | "conversation_updated"
   | "conversation_deleted";
@@ -25,6 +27,7 @@ interface UseMemoryEventsOptions {
   onConversationCreated?: (conversationId: number, data: unknown) => void;
   onConversationUpdated?: (conversationId: number, data: unknown) => void;
   onConversationDeleted?: (conversationId: number) => void;
+  onSkillExecuted?: (memoryId: number, data: unknown) => void;
   onConnected?: () => void;
   onError?: (error: unknown) => void;
   enabled?: boolean;
@@ -37,6 +40,7 @@ export function useMemoryEvents({
   onConversationCreated,
   onConversationUpdated,
   onConversationDeleted,
+  onSkillExecuted,
   onConnected,
   onError,
   enabled = true,
@@ -52,6 +56,7 @@ export function useMemoryEvents({
   const onConversationCreatedRef = useRef(onConversationCreated);
   const onConversationUpdatedRef = useRef(onConversationUpdated);
   const onConversationDeletedRef = useRef(onConversationDeleted);
+  const onSkillExecutedRef = useRef(onSkillExecuted);
   const onConnectedRef = useRef(onConnected);
   const onErrorRef = useRef(onError);
 
@@ -63,6 +68,7 @@ export function useMemoryEvents({
     onConversationCreatedRef.current = onConversationCreated;
     onConversationUpdatedRef.current = onConversationUpdated;
     onConversationDeletedRef.current = onConversationDeleted;
+    onSkillExecutedRef.current = onSkillExecuted;
     onConnectedRef.current = onConnected;
     onErrorRef.current = onError;
   });
@@ -124,6 +130,11 @@ export function useMemoryEvents({
             case "conversation_deleted":
               if (data.memory_id !== undefined) {
                 onConversationDeletedRef.current?.(data.memory_id);
+              }
+              break;
+            case "skill_executed":
+              if (data.memory_id !== undefined) {
+                onSkillExecutedRef.current?.(data.memory_id, data.data);
               }
               break;
           }

--- a/app/src/hooks/useSkills.ts
+++ b/app/src/hooks/useSkills.ts
@@ -1,0 +1,632 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  getSkills,
+  getSkillExecutions,
+  getSkillsList,
+  getSkillWithPrompt,
+  getExecutionHistory,
+  createSkill as apiCreateSkill,
+  updateSkill as apiUpdateSkill,
+  deleteSkill as apiDeleteSkill,
+  importSkill as apiImportSkill,
+  toggleSkillVisibility as apiToggleVisibility,
+  apiFetch,
+  type Skill,
+  type SkillExecution,
+  type SkillExecuteRequest,
+  type SkillListItem,
+  type SkillsListFilters,
+  type SkillCreateRequest,
+  type SkillUpdateRequest,
+  type SkillImportRequest,
+  type SkillTestRequest,
+  type ExecutionHistoryItem,
+  type ExecutionHistoryFilters,
+  getTriggers,
+  createTrigger as apiCreateTrigger,
+  updateTrigger as apiUpdateTrigger,
+  deleteTrigger as apiDeleteTrigger,
+  toggleTriggerEnabled as apiToggleTrigger,
+  previewTrigger as apiPreviewTrigger,
+  type SkillTrigger,
+  type TriggerCreateRequest,
+  type TriggerUpdateRequest,
+  type TriggerConditions,
+  type TriggerPreviewResult,
+} from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// SSE stream parsing helper (shared by useSkillExecution and useSkillTest)
+// ---------------------------------------------------------------------------
+
+interface SSECallbacks {
+  onMeta: (data: Record<string, unknown>) => void;
+  onToken: (content: string) => void;
+  onDone: () => void;
+  onError: (message: string) => void;
+}
+
+async function parseSSEStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  callbacks: SSECallbacks,
+) {
+  const decoder = new TextDecoder();
+  let sseBuffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      sseBuffer += decoder.decode(value, { stream: true });
+      const lines = sseBuffer.split("\n");
+      sseBuffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (line.startsWith("data: ")) {
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === "meta") {
+              callbacks.onMeta(data);
+            } else if (data.type === "token") {
+              callbacks.onToken(data.content);
+            } else if (data.type === "done") {
+              callbacks.onDone();
+            } else if (data.type === "error") {
+              callbacks.onError(data.message);
+            }
+          } catch (e) {
+            console.warn("Failed to parse skill SSE data:", line.slice(6), e);
+          }
+        }
+      }
+    }
+
+    // Process remaining buffer
+    if (sseBuffer.startsWith("data: ")) {
+      try {
+        const data = JSON.parse(sseBuffer.slice(6));
+        if (data.type === "token") {
+          callbacks.onToken(data.content);
+        } else if (data.type === "done") {
+          callbacks.onDone();
+        } else if (data.type === "error") {
+          callbacks.onError(data.message);
+        }
+      } catch {
+        // Ignore incomplete final chunk
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 hooks (unchanged)
+// ---------------------------------------------------------------------------
+
+export function useSkills() {
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSkills = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getSkills();
+      setSkills(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load skills");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSkills();
+  }, [loadSkills]);
+
+  return { skills, isLoading, error, refresh: loadSkills };
+}
+
+// --- useSkillExecution: State machine for executing a skill ---
+
+type ExecutionState = "idle" | "running" | "done" | "error";
+
+export function useSkillExecution() {
+  const [state, setState] = useState<ExecutionState>("idle");
+  const [result, setResult] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [executionId, setExecutionId] = useState<number | null>(null);
+  const [contentSource, setContentSource] = useState<string | null>(null);
+  const [contentWarning, setContentWarning] = useState<string | null>(null);
+  const [skillName, setSkillName] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const execute = useCallback(async (request: SkillExecuteRequest) => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setState("running");
+    setResult("");
+    setError(null);
+    setExecutionId(null);
+    setContentSource(null);
+    setContentWarning(null);
+    setSkillName(null);
+
+    let content = "";
+
+    try {
+      const res = await apiFetch("/api/skills/execute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+        signal: abortController.signal,
+      });
+
+      if (!res.ok) throw new Error("Failed to execute skill");
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No reader available");
+
+      await parseSSEStream(reader, {
+        onMeta: (data) => {
+          if (data.execution_id) setExecutionId(data.execution_id as number);
+          if (data.skill_name) setSkillName(data.skill_name as string);
+          if (data.content_source) setContentSource(data.content_source as string);
+          if (data.content_warning) setContentWarning(data.content_warning as string);
+        },
+        onToken: (token) => {
+          content += token;
+          setResult(content);
+        },
+        onDone: () => setState("done"),
+        onError: (message) => {
+          setError(message);
+          setState("error");
+        },
+      });
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Execution failed");
+      setState("error");
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    setState("idle");
+    setResult("");
+    setError(null);
+    setExecutionId(null);
+    setContentSource(null);
+    setContentWarning(null);
+    setSkillName(null);
+  }, []);
+
+  return {
+    state,
+    result,
+    error,
+    executionId,
+    contentSource,
+    contentWarning,
+    skillName,
+    execute,
+    reset,
+  };
+}
+
+// --- useSkillHistory: Load execution history for a memory ---
+
+export function useSkillHistory(memoryId: number | null) {
+  const [executions, setExecutions] = useState<SkillExecution[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadHistory = useCallback(async () => {
+    if (!memoryId) return;
+    setIsLoading(true);
+    try {
+      const data = await getSkillExecutions(memoryId);
+      setExecutions(data);
+    } catch {
+      // Silent failure - history may not exist yet
+    } finally {
+      setIsLoading(false);
+    }
+  }, [memoryId]);
+
+  useEffect(() => {
+    loadHistory();
+  }, [loadHistory]);
+
+  return { executions, isLoading, refresh: loadHistory };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 hooks
+// ---------------------------------------------------------------------------
+
+// --- useSkillsList: Skills list with filtering ---
+
+export function useSkillsList(filters: SkillsListFilters = {}) {
+  const [skills, setSkills] = useState<SkillListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const filtersKey = JSON.stringify(filters);
+
+  const loadSkills = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getSkillsList(filters);
+      setSkills(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load skills");
+    } finally {
+      setIsLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtersKey]);
+
+  useEffect(() => {
+    loadSkills();
+  }, [loadSkills]);
+
+  return { skills, isLoading, error, refresh: loadSkills };
+}
+
+// --- useSkillDetail: Single skill with prompt + recent executions ---
+
+export function useSkillDetail(skillId: string | null) {
+  const [skill, setSkill] = useState<Skill | null>(null);
+  const [recentExecutions, setRecentExecutions] = useState<ExecutionHistoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!skillId) {
+      setSkill(null);
+      setRecentExecutions([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const [skillData, historyData] = await Promise.all([
+        getSkillWithPrompt(skillId),
+        getExecutionHistory({ skill_id: skillId, limit: 10 }),
+      ]);
+      setSkill(skillData);
+      setRecentExecutions(historyData.executions);
+    } catch {
+      setSkill(null);
+      setRecentExecutions([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [skillId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { skill, recentExecutions, isLoading, refresh: load };
+}
+
+// --- useSkillMutations: CRUD + import + toggle visibility ---
+
+export function useSkillMutations() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useCallback(async (data: SkillCreateRequest): Promise<SkillListItem> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      return await apiCreateSkill(data);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to create skill";
+      setError(msg);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const update = useCallback(async (id: string, data: SkillUpdateRequest): Promise<SkillListItem> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      return await apiUpdateSkill(id, data);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to update skill";
+      setError(msg);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const remove = useCallback(async (id: string): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await apiDeleteSkill(id);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to delete skill";
+      setError(msg);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const importSkillFn = useCallback(async (req: SkillImportRequest): Promise<SkillListItem> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      return await apiImportSkill(req);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to import skill";
+      setError(msg);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const toggleVisibility = useCallback(async (id: string, hidden: boolean): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await apiToggleVisibility(id, hidden);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to toggle visibility";
+      setError(msg);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { create, update, remove, importSkill: importSkillFn, toggleVisibility, isLoading, error };
+}
+
+// --- useExecutionHistory: Paginated global history ---
+
+export function useExecutionHistory(filters: ExecutionHistoryFilters) {
+  const [executions, setExecutions] = useState<ExecutionHistoryItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const filtersKey = JSON.stringify(filters);
+  const offsetRef = useRef(0);
+
+  const load = useCallback(async (reset = false) => {
+    setIsLoading(true);
+    try {
+      const currentOffset = reset ? 0 : offsetRef.current;
+      const data = await getExecutionHistory({
+        ...filters,
+        offset: currentOffset,
+      });
+      if (reset) {
+        setExecutions(data.executions);
+      } else {
+        setExecutions((prev) => [...prev, ...data.executions]);
+      }
+      setTotal(data.total);
+      offsetRef.current = currentOffset + data.executions.length;
+      setHasMore(currentOffset + data.executions.length < data.total);
+    } catch {
+      // Silent failure
+    } finally {
+      setIsLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtersKey]);
+
+  useEffect(() => {
+    offsetRef.current = 0;
+    load(true);
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (!isLoading && hasMore) {
+      load(false);
+    }
+  }, [isLoading, hasMore, load]);
+
+  const refresh = useCallback(() => {
+    offsetRef.current = 0;
+    load(true);
+  }, [load]);
+
+  return { executions, total, isLoading, hasMore, loadMore, refresh };
+}
+
+// --- useSkillTest: Test execution state machine (no DB tracking) ---
+
+export function useSkillTest() {
+  const [state, setState] = useState<ExecutionState>("idle");
+  const [result, setResult] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [contentSource, setContentSource] = useState<string | null>(null);
+  const [contentWarning, setContentWarning] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const execute = useCallback(async (request: SkillTestRequest) => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    setState("running");
+    setResult("");
+    setError(null);
+    setContentSource(null);
+    setContentWarning(null);
+
+    let content = "";
+
+    try {
+      const res = await apiFetch("/api/skills/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+        signal: abortController.signal,
+      });
+
+      if (!res.ok) throw new Error("Failed to test skill");
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No reader available");
+
+      await parseSSEStream(reader, {
+        onMeta: (data) => {
+          if (data.content_source) setContentSource(data.content_source as string);
+          if (data.content_warning) setContentWarning(data.content_warning as string);
+        },
+        onToken: (token) => {
+          content += token;
+          setResult(content);
+        },
+        onDone: () => setState("done"),
+        onError: (message) => {
+          setError(message);
+          setState("error");
+        },
+      });
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setError(err instanceof Error ? err.message : "Test failed");
+      setState("error");
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    setState("idle");
+    setResult("");
+    setError(null);
+    setContentSource(null);
+    setContentWarning(null);
+  }, []);
+
+  return { state, result, error, contentSource, contentWarning, execute, reset };
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 hooks: Triggers
+// ---------------------------------------------------------------------------
+
+export function useTriggers(skillId: string | null) {
+  const [triggers, setTriggers] = useState<SkillTrigger[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!skillId) {
+      setTriggers([]);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const data = await getTriggers(skillId);
+      setTriggers(data);
+    } catch {
+      setTriggers([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [skillId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const create = useCallback(
+    async (data: TriggerCreateRequest) => {
+      if (!skillId) throw new Error("No skill selected");
+      const result = await apiCreateTrigger(skillId, data);
+      await load();
+      return result;
+    },
+    [skillId, load]
+  );
+
+  const update = useCallback(
+    async (triggerId: number, data: TriggerUpdateRequest) => {
+      const result = await apiUpdateTrigger(triggerId, data);
+      await load();
+      return result;
+    },
+    [load]
+  );
+
+  const remove = useCallback(
+    async (triggerId: number) => {
+      await apiDeleteTrigger(triggerId);
+      await load();
+    },
+    [load]
+  );
+
+  const toggle = useCallback(
+    async (triggerId: number, enabled: boolean) => {
+      const result = await apiToggleTrigger(triggerId, enabled);
+      await load();
+      return result;
+    },
+    [load]
+  );
+
+  return { triggers, isLoading, refresh: load, create, update, remove, toggle };
+}
+
+export function useTriggerPreview(conditions: TriggerConditions | null) {
+  const [preview, setPreview] = useState<TriggerPreviewResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!conditions || !conditions.rules.length) {
+      setPreview(null);
+      return;
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(async () => {
+      setIsLoading(true);
+      try {
+        const result = await apiPreviewTrigger(conditions);
+        setPreview(result);
+      } catch {
+        setPreview(null);
+      } finally {
+        setIsLoading(false);
+      }
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(conditions)]);
+
+  return { preview, isLoading };
+}

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -474,3 +474,432 @@ export async function batchCreateLinks(
 
   return response.json();
 }
+
+// ============================================================================
+// Skills API
+// ============================================================================
+
+export interface SkillParameter {
+  id: string;
+  label: string;
+  description?: string;
+  type: "select" | "boolean" | "string" | "number";
+  options?: string[];
+  default: unknown;
+}
+
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  logo: string | null;
+  version: string;
+  category: string;
+  tags: string[];
+  parameters: SkillParameter[];
+  input: {
+    type: string;
+    accepts: string[] | null;
+  };
+  prompt?: {
+    system: string;
+    user_template: string;
+  };
+  source?: string;
+  hidden?: boolean;
+  author_name?: string | null;
+  author_url?: string | null;
+  output_format?: string;
+  created_at?: string;
+  updated_at?: string;
+  triggers?: SkillTrigger[];
+}
+
+export interface SkillExecution {
+  id: number;
+  skill_id: string;
+  skill_name: string;
+  skill_icon: string;
+  skill_logo: string | null;
+  memory_id: number;
+  trigger_type: string;
+  parameters: Record<string, unknown> | null;
+  status: "running" | "completed" | "failed";
+  result: string | null;
+  error: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+}
+
+export interface SkillExecuteRequest {
+  skill_id: string;
+  memory_id: number;
+  parameters?: Record<string, unknown>;
+}
+
+export async function getSkills(): Promise<Skill[]> {
+  const response = await apiFetch("/api/skills");
+  if (!response.ok) {
+    throw new Error("Failed to fetch skills");
+  }
+  return response.json();
+}
+
+export async function getSkillWithPrompt(skillId: string): Promise<Skill> {
+  const response = await apiFetch(`/api/skills/${skillId}`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch skill details");
+  }
+  return response.json();
+}
+
+export async function toggleSkillVisibility(
+  skillId: string,
+  hidden: boolean
+): Promise<void> {
+  const response = await apiFetch(`/api/skills/${skillId}/visibility`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hidden }),
+  });
+  if (!response.ok) {
+    throw new Error("Failed to update skill visibility");
+  }
+}
+
+export async function getSkillExecutions(
+  memoryId: number
+): Promise<SkillExecution[]> {
+  const response = await apiFetch(
+    `/api/skills/executions?memory_id=${memoryId}`
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch skill executions");
+  }
+  return response.json();
+}
+
+// ============================================================================
+// Skills API — Phase 2 Extensions
+// ============================================================================
+
+export interface SkillListItem extends Skill {
+  source: "builtin" | "user";
+  hidden: boolean;
+  execution_count: number;
+  last_executed_at: string | null;
+  author_name: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SkillCreateRequest {
+  name: string;
+  description: string;
+  icon: string;
+  logo?: string | null;
+  category: string;
+  tags: string[];
+  input_type: string;
+  input_accepts: string[] | null;
+  parameters: SkillParameter[];
+  prompt_system: string;
+  prompt_user_template: string;
+  output_format?: string;
+  author_name?: string | null;
+  author_url?: string | null;
+}
+
+export type SkillUpdateRequest = Partial<SkillCreateRequest>;
+
+export interface SkillTestRequest {
+  memory_id: number;
+  prompt_system: string;
+  prompt_user_template: string;
+  parameters: SkillParameter[] | null;
+  parameter_values: Record<string, unknown>;
+  input_accepts: string[] | null;
+  output_format?: string;
+}
+
+export interface SkillValidationResult {
+  valid: boolean;
+  errors?: string[];
+  warnings?: string[];
+  parsed?: { name: string; id: string } | null;
+}
+
+export interface SkillImportRequest {
+  definition: string;
+  conflict_resolution: "replace" | "copy";
+}
+
+export interface ExecutionHistoryItem extends SkillExecution {
+  memory_title: string;
+  memory_type: string;
+  duration_seconds: number | null;
+}
+
+export interface ExecutionHistoryResponse {
+  executions: ExecutionHistoryItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface SkillsListFilters {
+  include_hidden?: boolean;
+  source?: "builtin" | "user";
+  category?: string;
+  search?: string;
+}
+
+export interface ExecutionHistoryFilters {
+  skill_id?: string;
+  memory_id?: number;
+  status?: "completed" | "failed";
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function getSkillsList(
+  filters: SkillsListFilters = {}
+): Promise<SkillListItem[]> {
+  const params = new URLSearchParams();
+  if (filters.include_hidden) params.set("include_hidden", "true");
+  if (filters.source) params.set("source", filters.source);
+  if (filters.category) params.set("category", filters.category);
+  if (filters.search) params.set("search", filters.search);
+  const response = await apiFetch(`/api/skills?${params}`);
+  if (!response.ok) throw new Error("Failed to fetch skills");
+  return response.json();
+}
+
+export async function createSkill(
+  data: SkillCreateRequest
+): Promise<SkillListItem> {
+  const response = await apiFetch("/api/skills", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: "Failed to create skill" }));
+    throw new ApiError(error.detail || "Failed to create skill", response.status);
+  }
+  return response.json();
+}
+
+export async function updateSkill(
+  id: string,
+  data: SkillUpdateRequest
+): Promise<SkillListItem> {
+  const response = await apiFetch(`/api/skills/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: "Failed to update skill" }));
+    throw new ApiError(error.detail || "Failed to update skill", response.status);
+  }
+  return response.json();
+}
+
+export async function deleteSkill(id: string): Promise<void> {
+  const response = await apiFetch(`/api/skills/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: "Failed to delete skill" }));
+    throw new ApiError(error.detail || "Failed to delete skill", response.status);
+  }
+}
+
+export async function validateSkillDefinition(
+  definition: string
+): Promise<SkillValidationResult> {
+  const response = await apiFetch("/api/skills/validate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ definition }),
+  });
+  if (!response.ok) throw new Error("Failed to validate skill");
+  return response.json();
+}
+
+export async function importSkill(
+  req: SkillImportRequest
+): Promise<SkillListItem> {
+  const response = await apiFetch("/api/skills/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: "Failed to import skill" }));
+    throw new ApiError(error.detail?.message || error.detail || "Failed to import skill", response.status);
+  }
+  return response.json();
+}
+
+export async function exportSkill(id: string): Promise<Blob> {
+  const response = await apiFetch(`/api/skills/${id}/export`);
+  if (!response.ok) throw new Error("Failed to export skill");
+  return response.blob();
+}
+
+export async function getExecutionHistory(
+  filters: ExecutionHistoryFilters = {}
+): Promise<ExecutionHistoryResponse> {
+  const params = new URLSearchParams();
+  if (filters.skill_id) params.set("skill_id", filters.skill_id);
+  if (filters.memory_id) params.set("memory_id", String(filters.memory_id));
+  if (filters.status) params.set("status", filters.status);
+  if (filters.search) params.set("search", filters.search);
+  if (filters.limit) params.set("limit", String(filters.limit));
+  if (filters.offset) params.set("offset", String(filters.offset));
+  const response = await apiFetch(`/api/skills/executions?${params}`);
+  if (!response.ok) throw new Error("Failed to fetch execution history");
+  return response.json();
+}
+
+// ============================================================================
+// Skill Triggers API (Phase 3)
+// ============================================================================
+
+export interface TriggerRule {
+  field: string;
+  op: string;
+  value: string | number | boolean;
+}
+
+export interface TriggerConditions {
+  operator: "AND" | "OR";
+  rules: TriggerRule[];
+}
+
+export interface SkillTrigger {
+  id: number;
+  skill_id: string;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  event_type: string;
+  conditions: TriggerConditions;
+  parameters: Record<string, unknown> | null;
+  execution_count: number;
+  last_triggered_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TriggerCreateRequest {
+  name: string;
+  description?: string;
+  event_type?: string;
+  conditions: TriggerConditions;
+  parameters?: Record<string, unknown>;
+}
+
+export interface TriggerUpdateRequest {
+  name?: string;
+  description?: string;
+  conditions?: TriggerConditions;
+  parameters?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface TriggerPreviewResult {
+  matching_count: number;
+  matching_memories: Array<{
+    id: number;
+    title: string | null;
+    type: string;
+    tags: string[];
+  }>;
+  total_memories: number;
+}
+
+export async function getTriggers(skillId: string): Promise<SkillTrigger[]> {
+  const response = await apiFetch(`/api/skills/${skillId}/triggers`);
+  if (!response.ok) throw new Error("Failed to fetch triggers");
+  return response.json();
+}
+
+export async function createTrigger(
+  skillId: string,
+  data: TriggerCreateRequest
+): Promise<SkillTrigger> {
+  const response = await apiFetch(`/api/skills/${skillId}/triggers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: "Failed to create trigger" }));
+    throw new ApiError(
+      error.detail || "Failed to create trigger",
+      response.status
+    );
+  }
+  return response.json();
+}
+
+export async function updateTrigger(
+  triggerId: number,
+  data: TriggerUpdateRequest
+): Promise<SkillTrigger> {
+  const response = await apiFetch(`/api/skills/triggers/${triggerId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: "Failed to update trigger" }));
+    throw new ApiError(
+      error.detail || "Failed to update trigger",
+      response.status
+    );
+  }
+  return response.json();
+}
+
+export async function deleteTrigger(triggerId: number): Promise<void> {
+  const response = await apiFetch(`/api/skills/triggers/${triggerId}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) throw new Error("Failed to delete trigger");
+}
+
+export async function toggleTriggerEnabled(
+  triggerId: number,
+  enabled: boolean
+): Promise<SkillTrigger> {
+  const response = await apiFetch(`/api/skills/triggers/${triggerId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  if (!response.ok) throw new Error("Failed to toggle trigger");
+  return response.json();
+}
+
+export async function previewTrigger(
+  conditions: TriggerConditions
+): Promise<TriggerPreviewResult> {
+  const response = await apiFetch("/api/skills/triggers/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ conditions }),
+  });
+  if (!response.ok) throw new Error("Failed to preview trigger");
+  return response.json();
+}

--- a/app/src/lib/design-tokens.ts
+++ b/app/src/lib/design-tokens.ts
@@ -8,6 +8,7 @@ export const glass = {
   base: "bg-white/70 dark:bg-white/5 backdrop-blur-md border border-white/60 dark:border-white/10 shadow-sm shadow-black/5 dark:shadow-black/20",
   hover:
     "hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30 hover:scale-[1.01] hover:-translate-y-0.5 transition-all duration-200",
+  elevated: "bg-white/60 dark:bg-white/[0.05] backdrop-blur-lg border border-white/50 dark:border-white/[0.08] shadow-md shadow-black/5 dark:shadow-black/20",
   panel: "bg-white/60 dark:bg-white/[0.04] backdrop-blur-xl border border-white/50 dark:border-white/[0.08] shadow-md",
   card: "bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm border border-white/40 dark:border-white/[0.06]",
   overlay: "bg-white/40 dark:bg-white/[0.03] backdrop-blur-md border border-white/30 dark:border-white/[0.05]",
@@ -77,3 +78,25 @@ export const communityColors = [
 export function getCommunityColor(index: number): string {
   return communityColors[index % communityColors.length];
 }
+
+// Skill category colors — distinct colors for visual scanning
+export const skillCategoryColors = {
+  productivity: { bg: "bg-blue-500/10",    text: "text-blue-600 dark:text-blue-400",    border: "border-blue-500/20",    dot: "bg-blue-500" },
+  analysis:     { bg: "bg-violet-500/10",   text: "text-violet-600 dark:text-violet-400", border: "border-violet-500/20",  dot: "bg-violet-500" },
+  export:       { bg: "bg-emerald-500/10",  text: "text-emerald-600 dark:text-emerald-400", border: "border-emerald-500/20", dot: "bg-emerald-500" },
+  writing:      { bg: "bg-amber-500/10",    text: "text-amber-600 dark:text-amber-400",   border: "border-amber-500/20",   dot: "bg-amber-500" },
+  research:     { bg: "bg-cyan-500/10",     text: "text-cyan-600 dark:text-cyan-400",     border: "border-cyan-500/20",    dot: "bg-cyan-500" },
+  custom:       { bg: "bg-pink-500/10",     text: "text-pink-600 dark:text-pink-400",     border: "border-pink-500/20",    dot: "bg-pink-500" },
+} as const;
+
+export function getSkillCategoryColor(category: string) {
+  return skillCategoryColors[category as keyof typeof skillCategoryColors]
+    ?? { bg: "bg-slate-500/10", text: "text-slate-500", border: "border-slate-500/20", dot: "bg-slate-500" };
+}
+
+// Execution status colors
+export const executionStatus = {
+  completed: { bg: "bg-emerald-500/10", text: "text-emerald-600 dark:text-emerald-400", icon: "text-emerald-500", dot: "bg-emerald-500" },
+  running:   { bg: "bg-amber-500/10",   text: "text-amber-600 dark:text-amber-400",     icon: "text-amber-500",   dot: "bg-amber-500" },
+  failed:    { bg: "bg-red-500/10",      text: "text-red-600 dark:text-red-400",         icon: "text-red-500",     dot: "bg-red-500" },
+} as const;

--- a/app/src/pages/ChatPage.tsx
+++ b/app/src/pages/ChatPage.tsx
@@ -9,7 +9,7 @@ import { ContextUsageIndicator } from "@/components/ContextUsageIndicator";
 import { AttachedMemoryChips } from "@/components/AttachedMemoryChips";
 import { useConversation } from "@/contexts/ConversationContext";
 import { useConversations } from "@/hooks/useConversations";
-import type { ChatMessage } from "@/types/chat";
+import type { ChatMessage, SkillSuggestion } from "@/types/chat";
 import { FileText, Pin, Trash2, Brain } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -18,6 +18,8 @@ export default function ChatPage() {
   const [message, setMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [followupSuggestions, setFollowupSuggestions] = useState<string[]>([]);
+  const [skillSuggestions, setSkillSuggestions] = useState<SkillSuggestion[]>([]);
+  const [isExecutingSkill, setIsExecutingSkill] = useState(false);
   const [useMemories, setUseMemories] = useState(true);
   const isStartingNewChatRef = useRef(false);
   const wantsNewChatRef = useRef(false);
@@ -87,8 +89,9 @@ export default function ChatPage() {
     // Clear new chat flag since user is now sending a message
     wantsNewChatRef.current = false;
 
-    // Clear previous follow-up suggestions when sending a new message
+    // Clear previous follow-up and skill suggestions when sending a new message
     setFollowupSuggestions([]);
+    setSkillSuggestions([]);
 
     // Capture attached memories before clearing (they're consumed with this message)
     const memoriesToSend = [...attachedMemories];
@@ -190,6 +193,10 @@ export default function ChatPage() {
                     sources: data.sources || [],
                     searched: data.searched || false,
                   });
+                  // Parse skill suggestions from meta event
+                  if (data.skill_suggestions && Array.isArray(data.skill_suggestions)) {
+                    setSkillSuggestions(data.skill_suggestions);
+                  }
                 } else if (data.type === "token") {
                   content += data.content;
                   updateMessage(assistantMessageId, { content });
@@ -260,6 +267,124 @@ export default function ChatPage() {
   const handleChat = useCallback(() => {
     submitChat(message, currentConversationId);
   }, [message, currentConversationId, submitChat]);
+
+  // Handler for executing a skill suggestion inline in chat
+  const handleExecuteSkill = useCallback(async (suggestion: SkillSuggestion) => {
+    if (!currentConversationId) return;
+
+    setIsExecutingSkill(true);
+    setSkillSuggestions([]); // Clear suggestions once one is selected
+
+    const assistantMessageId = crypto.randomUUID();
+    addMessage({
+      id: assistantMessageId,
+      role: "assistant",
+      content: "",
+      timestamp: new Date(),
+      isStreaming: true,
+      metadata: {
+        skill_execution_id: -1, // Placeholder until meta arrives
+        skill_id: suggestion.skill_id,
+        skill_name: suggestion.skill_name,
+        skill_icon: suggestion.skill_icon,
+        memory_id: suggestion.memory_id,
+        memory_title: suggestion.memory_title,
+      },
+    });
+
+    let content = "";
+
+    try {
+      const res = await apiFetch("/api/chat/execute-skill", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          skill_id: suggestion.skill_id,
+          memory_id: suggestion.memory_id,
+          conversation_id: currentConversationId,
+          parameters: suggestion.auto_parameters,
+        }),
+      });
+
+      if (!res.ok) throw new Error("Failed to execute skill");
+
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error("No reader available");
+
+      try {
+        const decoder = new TextDecoder();
+        let sseBuffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          sseBuffer += decoder.decode(value, { stream: true });
+          const lines = sseBuffer.split("\n");
+          sseBuffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              try {
+                const data = JSON.parse(line.slice(6));
+                if (data.type === "meta") {
+                  updateMessage(assistantMessageId, {
+                    metadata: {
+                      skill_execution_id: data.execution_id,
+                      skill_id: suggestion.skill_id,
+                      skill_name: data.skill_name || suggestion.skill_name,
+                      skill_icon: data.skill_icon || suggestion.skill_icon,
+                      memory_id: suggestion.memory_id,
+                      memory_title: suggestion.memory_title,
+                    },
+                  });
+                } else if (data.type === "token") {
+                  content += data.content;
+                  updateMessage(assistantMessageId, { content });
+                } else if (data.type === "done") {
+                  updateMessage(assistantMessageId, { isStreaming: false });
+                } else if (data.type === "error") {
+                  updateMessage(assistantMessageId, {
+                    content: data.message,
+                    error: true,
+                    isStreaming: false,
+                  });
+                }
+              } catch (e) {
+                console.warn("Failed to parse skill SSE data:", line.slice(6), e);
+              }
+            }
+          }
+        }
+
+        // Process remaining buffer
+        if (sseBuffer.startsWith("data: ")) {
+          try {
+            const data = JSON.parse(sseBuffer.slice(6));
+            if (data.type === "token") {
+              content += data.content;
+              updateMessage(assistantMessageId, { content });
+            } else if (data.type === "done") {
+              updateMessage(assistantMessageId, { isStreaming: false });
+            }
+          } catch {
+            // Ignore incomplete final chunk
+          }
+        }
+      } finally {
+        reader.cancel().catch(() => {});
+      }
+    } catch (err) {
+      updateMessage(assistantMessageId, {
+        content: "Failed to execute skill",
+        error: true,
+        isStreaming: false,
+      });
+      console.error("Skill execution failed:", err);
+    } finally {
+      setIsExecutingSkill(false);
+    }
+  }, [currentConversationId, addMessage, updateMessage]);
 
   // Effect: Handle ?new=true param from navigation (e.g., from HomePage "New Conversation")
   useEffect(() => {
@@ -354,6 +479,9 @@ export default function ChatPage() {
             isLoading={isLoading}
             onSendMessage={(msg) => submitChat(msg, currentConversationId)}
             followupSuggestions={followupSuggestions}
+            skillSuggestions={skillSuggestions}
+            onExecuteSkill={handleExecuteSkill}
+            isExecutingSkill={isExecutingSkill}
           />
         )}
 

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -105,6 +105,18 @@ export default function HomePage({ userName }: HomePageProps) {
     onMemoryDeleted: (memoryId) => {
       setRecentMemories((prev) => prev.filter((m) => m.id !== memoryId));
     },
+    onSkillExecuted: (_memoryId, data) => {
+      const info = data as { skill_name?: string; memory_title?: string; memory_id?: number };
+      toast.success(`${info.skill_name || "Skill"} executed`, {
+        description: info.memory_title || "on a memory",
+        action: info.memory_id
+          ? {
+              label: "View Result",
+              onClick: () => navigate(`/memories?open=${info.memory_id}`),
+            }
+          : undefined,
+      });
+    },
   });
 
   const fetchRecentMemories = async () => {

--- a/app/src/pages/SkillsPage.tsx
+++ b/app/src/pages/SkillsPage.tsx
@@ -1,0 +1,506 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Search,
+  Plus,
+  Download,
+  ChevronDown,
+  ChevronRight,
+  Zap,
+  SlidersHorizontal,
+  Clock,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { glass, chips, getSkillCategoryColor } from "@/lib/design-tokens";
+import { cn } from "@/lib/utils";
+import { useSkillsList } from "@/hooks/useSkills";
+import SkillDetail from "@/components/SkillDetail";
+import SkillExecutionHistory from "@/components/SkillExecutionHistory";
+import { SkillImportDialog } from "@/components/SkillImportDialog";
+import type { SkillListItem } from "@/lib/api";
+
+type TabMode = "browse" | "history";
+type SortBy = "alpha" | "recent_used" | "recent_created";
+
+const CATEGORIES = [
+  { value: "all", label: "All Categories" },
+  { value: "productivity", label: "Productivity" },
+  { value: "analysis", label: "Analysis" },
+  { value: "export", label: "Export" },
+  { value: "writing", label: "Writing" },
+  { value: "research", label: "Research" },
+  { value: "custom", label: "Custom" },
+];
+
+function SkillCard({
+  skill,
+  isSelected,
+  onClick,
+}: {
+  skill: SkillListItem;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const catColor = getSkillCategoryColor(skill.category);
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full text-left p-4 rounded-xl transition-all duration-200 group",
+        glass.card,
+        isSelected
+          ? "ring-2 ring-primary/40 bg-primary/5 dark:bg-primary/10 shadow-md shadow-primary/10"
+          : [
+              "hover:bg-white/60 dark:hover:bg-white/[0.06]",
+              "hover:shadow-md hover:shadow-black/5 dark:hover:shadow-black/20",
+              "hover:-translate-y-0.5",
+            ]
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            "h-9 w-9 rounded-lg flex items-center justify-center flex-shrink-0",
+            "bg-white/50 dark:bg-white/[0.04] border border-white/60 dark:border-white/10",
+            "group-hover:shadow-sm group-hover:shadow-primary/10 transition-all duration-200"
+          )}
+        >
+          {skill.logo ? (
+            <img src={skill.logo} alt="" className="h-5 w-5 rounded object-cover" />
+          ) : (
+            <span className="text-lg">{skill.icon}</span>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm truncate">{skill.name}</span>
+            <span className="text-[10px] text-muted-foreground/60 flex-shrink-0">
+              v{skill.version}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+            {skill.description}
+          </p>
+          <div className="flex items-center gap-1.5 mt-1.5">
+            <span
+              className={cn(
+                chips.base,
+                "text-[10px] py-0.5 border",
+                catColor.bg,
+                catColor.text,
+                catColor.border
+              )}
+            >
+              {skill.category}
+            </span>
+            {skill.execution_count > 0 && (
+              <span className="text-[10px] text-muted-foreground/50 flex items-center gap-0.5">
+                <Clock className="h-2.5 w-2.5" />
+                {skill.execution_count}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function SkillSection({
+  title,
+  skills,
+  selectedId,
+  onSelect,
+  collapsible = false,
+  defaultCollapsed = false,
+}: {
+  title: string;
+  skills: SkillListItem[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  collapsible?: boolean;
+  defaultCollapsed?: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  if (skills.length === 0) return null;
+
+  return (
+    <div className="mb-5">
+      <button
+        onClick={() => collapsible && setCollapsed(!collapsed)}
+        className={cn(
+          "flex items-center gap-2 text-[11px] font-semibold text-muted-foreground/60 uppercase tracking-widest mb-3 px-1 w-full",
+          collapsible && "cursor-pointer hover:text-muted-foreground transition-colors"
+        )}
+      >
+        <div className="h-px w-4 bg-primary/30 flex-shrink-0" />
+        {collapsible &&
+          (collapsed ? (
+            <ChevronRight className="h-3 w-3 flex-shrink-0" />
+          ) : (
+            <ChevronDown className="h-3 w-3 flex-shrink-0" />
+          ))}
+        {title}
+        <span className="text-muted-foreground/40">({skills.length})</span>
+        <div className="flex-1 h-px bg-border/50" />
+      </button>
+      {!collapsed && (
+        <div className="space-y-2">
+          {skills.map((skill, index) => (
+            <div
+              key={skill.id}
+              className="animate-stagger-fade-in opacity-0"
+              style={{
+                animationDelay: `${Math.min(index * 50, 1000)}ms`,
+                animationFillMode: "forwards",
+              }}
+            >
+              <SkillCard
+                skill={skill}
+                isSelected={selectedId === skill.id}
+                onClick={() => onSelect(skill.id)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SkillsPage() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabMode>("browse");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [sortBy, setSortBy] = useState<SortBy>("alpha");
+  const [sortOpen, setSortOpen] = useState(false);
+  const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [showImportDialog, setShowImportDialog] = useState(false);
+  const [importFileContent, setImportFileContent] = useState<string | null>(
+    null
+  );
+
+  const { skills, isLoading, refresh } = useSkillsList({
+    include_hidden: true,
+    search: searchQuery || undefined,
+    category: categoryFilter !== "all" ? categoryFilter : undefined,
+  });
+
+  // Listen for .think-skill file import events from Electron
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ filePath: string; content: string }>)
+        .detail;
+      setImportFileContent(detail.content);
+      setShowImportDialog(true);
+      setActiveTab("browse");
+    };
+    window.addEventListener("import-skill-file", handler);
+    return () => window.removeEventListener("import-skill-file", handler);
+  }, []);
+
+  // Sort and group skills
+  const sortSkills = useCallback(
+    (list: SkillListItem[]) => {
+      const sorted = [...list];
+      switch (sortBy) {
+        case "alpha":
+          sorted.sort((a, b) => a.name.localeCompare(b.name));
+          break;
+        case "recent_used":
+          sorted.sort((a, b) =>
+            (b.last_executed_at ?? "").localeCompare(
+              a.last_executed_at ?? ""
+            )
+          );
+          break;
+        case "recent_created":
+          sorted.sort((a, b) =>
+            (b.created_at ?? "").localeCompare(a.created_at ?? "")
+          );
+          break;
+      }
+      return sorted;
+    },
+    [sortBy]
+  );
+
+  const builtinSkills = useMemo(
+    () =>
+      sortSkills(
+        skills.filter((s) => s.source === "builtin" && !s.hidden)
+      ),
+    [skills, sortSkills]
+  );
+  const userSkills = useMemo(
+    () =>
+      sortSkills(
+        skills.filter((s) => s.source === "user" && !s.hidden)
+      ),
+    [skills, sortSkills]
+  );
+  const hiddenSkills = useMemo(
+    () => sortSkills(skills.filter((s) => s.hidden)),
+    [skills, sortSkills]
+  );
+
+  const totalSkills = builtinSkills.length + userSkills.length;
+
+  const handleSkillSelect = (id: string) => {
+    setSelectedSkillId(id === selectedSkillId ? null : id);
+  };
+
+  return (
+    <div className="p-8 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-xl bg-primary/10 flex items-center justify-center animate-glow-pulse">
+            <Zap className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-heading font-semibold">Skills</h1>
+            <p className="text-xs text-muted-foreground/60 mt-0.5">
+              {totalSkills} skill{totalSkills !== 1 ? "s" : ""} available
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setImportFileContent(null);
+              setShowImportDialog(true);
+            }}
+            className="gap-1.5 hover:shadow-sm hover:shadow-primary/10 transition-all duration-200"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Import
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => navigate("/skills/new")}
+            className="gap-1.5 shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all duration-200"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New Skill
+          </Button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className={cn("inline-flex items-center gap-1 p-1 rounded-xl mb-6", glass.overlay)}>
+        {(["browse", "history"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={cn(
+              "px-5 py-2 text-sm rounded-lg transition-all duration-200 capitalize",
+              activeTab === tab
+                ? "bg-primary/15 text-primary font-medium shadow-sm shadow-primary/10"
+                : "text-muted-foreground hover:text-foreground hover:bg-white/40 dark:hover:bg-white/[0.04]"
+            )}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Browse Tab */}
+      {activeTab === "browse" && (
+        <>
+          {/* Search + Filters */}
+          <div className={cn("flex items-center gap-2 mb-6 p-2 rounded-xl", glass.overlay)}>
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground/40" />
+              <Input
+                placeholder="Search skills..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 h-9 bg-white/50 dark:bg-white/[0.03] border-white/40 dark:border-white/[0.06] focus-visible:ring-primary/30 focus-visible:shadow-sm focus-visible:shadow-primary/10 transition-shadow duration-200"
+              />
+            </div>
+
+            {/* Category filter */}
+            <Popover open={categoryOpen} onOpenChange={setCategoryOpen}>
+              <PopoverTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-1.5 h-9">
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                  {CATEGORIES.find((c) => c.value === categoryFilter)?.label ??
+                    "All"}
+                  <ChevronDown className="h-3 w-3 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-44 p-1" align="end">
+                {CATEGORIES.map((cat) => (
+                  <button
+                    key={cat.value}
+                    onClick={() => {
+                      setCategoryFilter(cat.value);
+                      setCategoryOpen(false);
+                    }}
+                    className={cn(
+                      "w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors",
+                      categoryFilter === cat.value
+                        ? "bg-primary/10 text-primary"
+                        : "hover:bg-muted"
+                    )}
+                  >
+                    {cat.label}
+                  </button>
+                ))}
+              </PopoverContent>
+            </Popover>
+
+            {/* Sort */}
+            <Popover open={sortOpen} onOpenChange={setSortOpen}>
+              <PopoverTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-1.5 h-9">
+                  Sort
+                  <ChevronDown className="h-3 w-3 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-44 p-1" align="end">
+                {[
+                  { value: "alpha" as const, label: "Alphabetical" },
+                  { value: "recent_used" as const, label: "Recently used" },
+                  {
+                    value: "recent_created" as const,
+                    label: "Recently created",
+                  },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => {
+                      setSortBy(opt.value);
+                      setSortOpen(false);
+                    }}
+                    className={cn(
+                      "w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors",
+                      sortBy === opt.value
+                        ? "bg-primary/10 text-primary"
+                        : "hover:bg-muted"
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          {/* Skill List */}
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary border-t-transparent" />
+            </div>
+          ) : builtinSkills.length === 0 &&
+            userSkills.length === 0 &&
+            hiddenSkills.length === 0 ? (
+            <div className="text-center py-20 animate-fade-in-up">
+              <div className="h-16 w-16 mx-auto rounded-2xl bg-primary/5 flex items-center justify-center mb-4">
+                <Zap className="h-8 w-8 text-muted-foreground/20" />
+              </div>
+              <p className="text-muted-foreground">
+                {searchQuery
+                  ? "No skills match your search."
+                  : "No skills found."}
+              </p>
+            </div>
+          ) : (
+            <div>
+              <SkillSection
+                title="Built-in"
+                skills={builtinSkills}
+                selectedId={selectedSkillId}
+                onSelect={handleSkillSelect}
+              />
+              <SkillSection
+                title="My Skills"
+                skills={userSkills}
+                selectedId={selectedSkillId}
+                onSelect={handleSkillSelect}
+              />
+              {userSkills.length === 0 && !searchQuery && (
+                <div
+                  className={cn(
+                    "rounded-xl p-6 text-center mb-5 animate-fade-in-up",
+                    glass.overlay
+                  )}
+                >
+                  <p className="text-sm text-muted-foreground mb-3">
+                    No custom skills yet. Create one or import a .think-skill
+                    file.
+                  </p>
+                  <div className="flex items-center justify-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setImportFileContent(null);
+                        setShowImportDialog(true);
+                      }}
+                    >
+                      <Download className="h-3.5 w-3.5 mr-1.5" />
+                      Import
+                    </Button>
+                    <Button size="sm" onClick={() => navigate("/skills/new")}>
+                      <Plus className="h-3.5 w-3.5 mr-1.5" />
+                      New Skill
+                    </Button>
+                  </div>
+                </div>
+              )}
+              <SkillSection
+                title="Hidden"
+                skills={hiddenSkills}
+                selectedId={selectedSkillId}
+                onSelect={handleSkillSelect}
+                collapsible
+                defaultCollapsed
+              />
+            </div>
+          )}
+        </>
+      )}
+
+      {/* History Tab */}
+      {activeTab === "history" && <SkillExecutionHistory />}
+
+      {/* Detail Panel */}
+      <SkillDetail
+        skillId={selectedSkillId}
+        isOpen={selectedSkillId !== null}
+        onClose={() => setSelectedSkillId(null)}
+        onDeleted={() => {
+          setSelectedSkillId(null);
+          refresh();
+        }}
+        onUpdated={refresh}
+      />
+
+      {/* Import Dialog */}
+      <SkillImportDialog
+        open={showImportDialog}
+        onOpenChange={setShowImportDialog}
+        initialContent={importFileContent}
+        onImported={() => {
+          setShowImportDialog(false);
+          setImportFileContent(null);
+          refresh();
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/types/chat.ts
+++ b/app/src/types/chat.ts
@@ -4,6 +4,18 @@ export interface SourceMemory {
   id: number;
   title: string;
   url?: string;
+  type?: string;
+}
+
+export interface SkillSuggestion {
+  skill_id: string;
+  skill_name: string;
+  skill_icon: string;
+  memory_id: number;
+  memory_title: string;
+  auto_parameters: Record<string, unknown>;
+  match_reason: string;
+  matched_pattern: string;
 }
 
 export interface AttachedMemory {
@@ -58,6 +70,15 @@ export interface TokenUsage {
   total_tokens: number;
 }
 
+export interface SkillMessageMetadata {
+  skill_execution_id?: number;
+  skill_id?: string;
+  skill_name?: string;
+  skill_icon?: string;
+  memory_id?: number;
+  memory_title?: string;
+}
+
 export interface ChatMessage {
   id: string | number;
   role: "user" | "assistant";
@@ -72,6 +93,8 @@ export interface ChatMessage {
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
+  // Skill execution metadata (for chat skill results)
+  metadata?: SkillMessageMetadata | null;
 }
 
 export interface Conversation {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -74,29 +74,37 @@ export default {
   		},
   		keyframes: {
   			'slide-up': {
-  				'0%': {
-  					opacity: '0',
-  					transform: 'translateY(10px)'
-  				},
-  				'100%': {
-  					opacity: '1',
-  					transform: 'translateY(0)'
-  				}
+  				'0%': { opacity: '0', transform: 'translateY(10px)' },
+  				'100%': { opacity: '1', transform: 'translateY(0)' }
   			},
   			'fade-in-up': {
-  				'0%': {
-  					opacity: '0',
-  					transform: 'translateY(4px)'
-  				},
-  				'100%': {
-  					opacity: '1',
-  					transform: 'translateY(0)'
-  				}
+  				'0%': { opacity: '0', transform: 'translateY(4px)' },
+  				'100%': { opacity: '1', transform: 'translateY(0)' }
+  			},
+  			'stagger-fade-in': {
+  				'0%': { opacity: '0', transform: 'translateY(8px)' },
+  				'100%': { opacity: '1', transform: 'translateY(0)' }
+  			},
+  			'scale-in': {
+  				'0%': { opacity: '0', transform: 'scale(0.95)' },
+  				'100%': { opacity: '1', transform: 'scale(1)' }
+  			},
+  			'slide-in-right': {
+  				'0%': { opacity: '0', transform: 'translateX(16px)' },
+  				'100%': { opacity: '1', transform: 'translateX(0)' }
+  			},
+  			'glow-pulse': {
+  				'0%, 100%': { boxShadow: '0 0 0 0 hsl(192 61% 59% / 0)' },
+  				'50%': { boxShadow: '0 0 12px 2px hsl(192 61% 59% / 0.15)' }
   			}
   		},
   		animation: {
   			'slide-up': 'slide-up 200ms ease-out',
-  			'fade-in-up': 'fade-in-up 150ms ease-out'
+  			'fade-in-up': 'fade-in-up 150ms ease-out',
+  			'stagger-fade-in': 'stagger-fade-in 250ms ease-out forwards',
+  			'scale-in': 'scale-in 200ms ease-out',
+  			'slide-in-right': 'slide-in-right 250ms ease-out',
+  			'glow-pulse': 'glow-pulse 2s ease-in-out infinite'
   		}
   	}
   },

--- a/backend/app/db/core.py
+++ b/backend/app/db/core.py
@@ -111,11 +111,13 @@ async def init_db(db_key: str):
             return
 
         from .migrations import run_migrations
+        from ..services.skills.registry import seed_builtin_skills
 
         with _engine.connect() as connection:
             applied = run_migrations(connection)
             for version, desc in applied:
                 print(f"Applied migration {version}: {desc}")
+            seed_builtin_skills(connection)
 
     await run_sync(setup_database)
 

--- a/backend/app/db/crud/conversations.py
+++ b/backend/app/db/crud/conversations.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from sqlalchemy import select, func, and_
 
@@ -129,6 +130,7 @@ async def get_conversation(conversation_id: int) -> dict | None:
                     "prompt_tokens": m.prompt_tokens,
                     "completion_tokens": m.completion_tokens,
                     "total_tokens": m.total_tokens,
+                    "metadata": json.loads(m.msg_metadata) if m.msg_metadata else None,
                 })
 
             return {
@@ -190,6 +192,7 @@ async def add_message(
     content: str,
     sources: list[dict] | None = None,
     usage: dict | None = None,
+    metadata: str | None = None,
 ) -> dict | None:
     """Add a message to a conversation with optional sources and token usage."""
     def _add():
@@ -209,6 +212,9 @@ async def add_message(
                 message.prompt_tokens = usage.get("prompt_tokens")
                 message.completion_tokens = usage.get("completion_tokens")
                 message.total_tokens = usage.get("total_tokens")
+
+            if metadata:
+                message.msg_metadata = metadata
 
             session.add(message)
             session.flush()  # Get message.id before adding sources
@@ -239,6 +245,7 @@ async def add_message(
                 "prompt_tokens": message.prompt_tokens,
                 "completion_tokens": message.completion_tokens,
                 "total_tokens": message.total_tokens,
+                "metadata": json.loads(message.msg_metadata) if message.msg_metadata else None,
             }
 
     return await run_sync(_add)

--- a/backend/app/db/crud/skills.py
+++ b/backend/app/db/crud/skills.py
@@ -1,0 +1,829 @@
+import json
+import uuid as uuid_mod
+from datetime import datetime
+from sqlalchemy import select, update, func as sa_func
+
+from ..core import get_session_maker, run_sync
+from ...models import Skill, SkillExecution, SkillTrigger, Memory, MemoryTag, Tag
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 functions (unchanged except get_skill which adds new fields)
+# ---------------------------------------------------------------------------
+
+async def get_skills() -> list[dict]:
+    """Get all non-hidden skills (without prompt/definition)."""
+    def _get():
+        with get_session_maker()() as session:
+            skills = session.execute(
+                select(Skill).where(Skill.hidden == False).order_by(Skill.name)  # noqa: E712
+            ).scalars().all()
+
+            return [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "description": s.description,
+                    "icon": s.icon,
+                    "logo": s.logo,
+                    "version": s.version,
+                    "category": s.category,
+                    "tags": json.loads(s.tags) if s.tags else [],
+                    "parameters": json.loads(s.parameters) if s.parameters else [],
+                    "input": {
+                        "type": s.input_type,
+                        "accepts": json.loads(s.input_accepts) if s.input_accepts else None,
+                    },
+                }
+                for s in skills
+            ]
+
+    return await run_sync(_get)
+
+
+async def get_skill(skill_id: str) -> dict | None:
+    """Get a single skill with prompt details."""
+    def _get():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return None
+
+            return {
+                "id": skill.id,
+                "name": skill.name,
+                "description": skill.description,
+                "icon": skill.icon,
+                "logo": skill.logo,
+                "version": skill.version,
+                "category": skill.category,
+                "tags": json.loads(skill.tags) if skill.tags else [],
+                "parameters": json.loads(skill.parameters) if skill.parameters else [],
+                "input": {
+                    "type": skill.input_type,
+                    "accepts": json.loads(skill.input_accepts) if skill.input_accepts else None,
+                },
+                "prompt": {
+                    "system": skill.prompt_system,
+                    "user_template": skill.prompt_user_template,
+                },
+                "source": skill.source,
+                "hidden": skill.hidden,
+                "author_name": skill.author_name,
+                "author_url": skill.author_url,
+                "output_format": skill.output_format,
+                "created_at": skill.created_at.isoformat() if skill.created_at else None,
+                "updated_at": skill.updated_at.isoformat() if skill.updated_at else None,
+            }
+
+    return await run_sync(_get)
+
+
+async def get_skill_for_execution(skill_id: str) -> dict | None:
+    """Get a single skill with all fields needed for execution."""
+    def _get():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return None
+
+            return {
+                "id": skill.id,
+                "name": skill.name,
+                "icon": skill.icon,
+                "input_type": skill.input_type,
+                "input_accepts": skill.input_accepts,
+                "parameters": skill.parameters,
+                "prompt_system": skill.prompt_system,
+                "prompt_user_template": skill.prompt_user_template,
+                "output_format": skill.output_format,
+            }
+
+    return await run_sync(_get)
+
+
+async def toggle_skill_visibility(skill_id: str, hidden: bool) -> bool:
+    """Toggle a skill's hidden status. Returns False if skill not found."""
+    def _toggle():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return False
+            skill.hidden = hidden
+            skill.updated_at = datetime.utcnow()
+            session.commit()
+            return True
+
+    return await run_sync(_toggle)
+
+
+async def create_execution(
+    skill_id: str,
+    memory_id: int,
+    trigger_type: str,
+    parameters: dict | None,
+) -> int:
+    """Create a new skill execution in 'running' status. Returns execution ID."""
+    def _create():
+        with get_session_maker()() as session:
+            execution = SkillExecution(
+                skill_id=skill_id,
+                memory_id=memory_id,
+                trigger_type=trigger_type,
+                parameters=json.dumps(parameters) if parameters else None,
+                status="running",
+                started_at=datetime.utcnow(),
+            )
+            session.add(execution)
+            session.commit()
+            session.refresh(execution)
+            return execution.id
+
+    return await run_sync(_create)
+
+
+async def update_execution_completed(execution_id: int, result: str) -> None:
+    """Mark execution as completed with result text."""
+    def _update():
+        with get_session_maker()() as session:
+            execution = session.get(SkillExecution, execution_id)
+            if execution:
+                execution.status = "completed"
+                execution.result = result
+                execution.completed_at = datetime.utcnow()
+                session.commit()
+
+    await run_sync(_update)
+
+
+async def update_execution_failed(execution_id: int, error: str) -> None:
+    """Mark execution as failed with error message."""
+    def _update():
+        with get_session_maker()() as session:
+            execution = session.get(SkillExecution, execution_id)
+            if execution:
+                execution.status = "failed"
+                execution.error = error
+                execution.completed_at = datetime.utcnow()
+                session.commit()
+
+    await run_sync(_update)
+
+
+async def get_skill_executions(memory_id: int) -> list[dict]:
+    """Get all skill executions for a memory, with skill_name and skill_icon via JOIN."""
+    def _get():
+        with get_session_maker()() as session:
+            results = session.execute(
+                select(SkillExecution, Skill.name, Skill.icon, Skill.logo)
+                .join(Skill, SkillExecution.skill_id == Skill.id)
+                .where(SkillExecution.memory_id == memory_id)
+                .order_by(SkillExecution.created_at.desc())
+            ).all()
+
+            return [
+                {
+                    "id": ex.id,
+                    "skill_id": ex.skill_id,
+                    "skill_name": skill_name,
+                    "skill_icon": skill_icon,
+                    "skill_logo": skill_logo,
+                    "memory_id": ex.memory_id,
+                    "trigger_type": ex.trigger_type,
+                    "parameters": json.loads(ex.parameters) if ex.parameters else None,
+                    "status": ex.status,
+                    "result": ex.result,
+                    "error": ex.error,
+                    "started_at": ex.started_at.isoformat() if ex.started_at else None,
+                    "completed_at": ex.completed_at.isoformat() if ex.completed_at else None,
+                    "created_at": ex.created_at.isoformat() if ex.created_at else None,
+                }
+                for ex, skill_name, skill_icon, skill_logo in results
+            ]
+
+    return await run_sync(_get)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 functions
+# ---------------------------------------------------------------------------
+
+def _skill_to_full_dict(skill: Skill) -> dict:
+    """Convert a Skill ORM object to a full response dict."""
+    return {
+        "id": skill.id,
+        "name": skill.name,
+        "description": skill.description,
+        "icon": skill.icon,
+        "logo": skill.logo,
+        "version": skill.version,
+        "category": skill.category,
+        "tags": json.loads(skill.tags) if skill.tags else [],
+        "source": skill.source,
+        "hidden": skill.hidden,
+        "author_name": skill.author_name,
+        "author_url": skill.author_url,
+        "parameters": json.loads(skill.parameters) if skill.parameters else [],
+        "input": {
+            "type": skill.input_type,
+            "accepts": json.loads(skill.input_accepts) if skill.input_accepts else None,
+        },
+        "prompt": {
+            "system": skill.prompt_system,
+            "user_template": skill.prompt_user_template,
+        },
+        "output_format": skill.output_format,
+        "created_at": skill.created_at.isoformat() if skill.created_at else None,
+        "updated_at": skill.updated_at.isoformat() if skill.updated_at else None,
+    }
+
+
+async def get_all_skills(
+    include_hidden: bool = False,
+    source_filter: str | None = None,
+    category_filter: str | None = None,
+    search: str | None = None,
+) -> list[dict]:
+    """Get skills with filtering, annotated with execution stats."""
+    def _get():
+        with get_session_maker()() as session:
+            # Subquery for execution stats per skill
+            exec_stats = (
+                select(
+                    SkillExecution.skill_id,
+                    sa_func.count(SkillExecution.id).label("execution_count"),
+                    sa_func.max(SkillExecution.started_at).label("last_executed_at"),
+                )
+                .group_by(SkillExecution.skill_id)
+                .subquery()
+            )
+
+            query = (
+                select(
+                    Skill,
+                    exec_stats.c.execution_count,
+                    exec_stats.c.last_executed_at,
+                )
+                .outerjoin(exec_stats, Skill.id == exec_stats.c.skill_id)
+            )
+
+            # Filters
+            if not include_hidden:
+                query = query.where(Skill.hidden == False)  # noqa: E712
+
+            if source_filter:
+                query = query.where(Skill.source == source_filter)
+
+            if category_filter:
+                query = query.where(Skill.category == category_filter)
+
+            if search:
+                like_pattern = f"%{search}%"
+                query = query.where(
+                    (Skill.name.ilike(like_pattern))
+                    | (Skill.description.ilike(like_pattern))
+                    | (Skill.tags.ilike(like_pattern))
+                )
+
+            query = query.order_by(Skill.name)
+            results = session.execute(query).all()
+
+            return [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "description": s.description,
+                    "icon": s.icon,
+                    "logo": s.logo,
+                    "version": s.version,
+                    "category": s.category,
+                    "tags": json.loads(s.tags) if s.tags else [],
+                    "source": s.source,
+                    "hidden": bool(s.hidden),
+                    "author_name": s.author_name,
+                    "parameters": json.loads(s.parameters) if s.parameters else [],
+                    "input": {
+                        "type": s.input_type,
+                        "accepts": json.loads(s.input_accepts) if s.input_accepts else None,
+                    },
+                    "execution_count": exec_count or 0,
+                    "last_executed_at": last_exec.isoformat() if last_exec else None,
+                    "created_at": s.created_at.isoformat() if s.created_at else None,
+                    "updated_at": s.updated_at.isoformat() if s.updated_at else None,
+                }
+                for s, exec_count, last_exec in results
+            ]
+
+    return await run_sync(_get)
+
+
+async def create_user_skill(data: dict) -> dict:
+    """Create a new user skill. Returns the full skill dict."""
+    def _create():
+        with get_session_maker()() as session:
+            from ...services.skills.registry import generate_skill_json
+
+            skill_id = data.get("id") or str(uuid_mod.uuid4())
+
+            # Build row data for definition generation
+            row_data = {
+                "id": skill_id,
+                "schema_version": 1,
+                "name": data["name"],
+                "description": data["description"],
+                "icon": data["icon"],
+                "logo": data.get("logo"),
+                "version": data.get("version", "1.0.0"),
+                "category": data.get("category", "custom"),
+                "tags": json.dumps(data.get("tags", [])),
+                "author_name": data.get("author_name"),
+                "author_url": data.get("author_url"),
+                "input_type": data.get("input_type", "single_memory"),
+                "input_accepts": json.dumps(data["input_accepts"]) if data.get("input_accepts") else None,
+                "parameters": json.dumps(data.get("parameters", [])),
+                "prompt_system": data["prompt_system"],
+                "prompt_user_template": data["prompt_user_template"],
+                "output_format": data.get("output_format", "markdown"),
+                "triggers": json.dumps(data.get("triggers")) if data.get("triggers") else None,
+            }
+            definition = generate_skill_json(row_data)
+
+            skill = Skill(
+                id=skill_id,
+                schema_version=1,
+                name=data["name"],
+                description=data["description"],
+                icon=data["icon"],
+                logo=data.get("logo"),
+                version=data.get("version", "1.0.0"),
+                category=data.get("category", "custom"),
+                tags=json.dumps(data.get("tags", [])),
+                author_name=data.get("author_name"),
+                author_url=data.get("author_url"),
+                input_type=data.get("input_type", "single_memory"),
+                input_accepts=json.dumps(data["input_accepts"]) if data.get("input_accepts") else None,
+                parameters=json.dumps(data.get("parameters", [])),
+                prompt_system=data["prompt_system"],
+                prompt_user_template=data["prompt_user_template"],
+                output_format=data.get("output_format", "markdown"),
+                triggers=json.dumps(data.get("triggers")) if data.get("triggers") else None,
+                source="user",
+                hidden=False,
+                definition=definition,
+            )
+            session.add(skill)
+            session.commit()
+            session.refresh(skill)
+            return _skill_to_full_dict(skill)
+
+    return await run_sync(_create)
+
+
+async def update_user_skill(skill_id: str, data: dict) -> dict | str | None:
+    """Update a user skill. Returns None if not found, 'builtin_protected' if builtin."""
+    def _update():
+        with get_session_maker()() as session:
+            from ...services.skills.registry import generate_skill_json
+
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return None
+            if skill.source != "user":
+                return "builtin_protected"
+
+            # Update provided fields
+            field_map = {
+                "name": "name",
+                "description": "description",
+                "icon": "icon",
+                "logo": "logo",
+                "version": "version",
+                "category": "category",
+                "input_type": "input_type",
+                "prompt_system": "prompt_system",
+                "prompt_user_template": "prompt_user_template",
+                "output_format": "output_format",
+                "author_name": "author_name",
+                "author_url": "author_url",
+            }
+            for data_key, attr_name in field_map.items():
+                if data_key in data:
+                    setattr(skill, attr_name, data[data_key])
+
+            # JSON fields
+            if "tags" in data:
+                skill.tags = json.dumps(data["tags"])
+            if "input_accepts" in data:
+                skill.input_accepts = json.dumps(data["input_accepts"]) if data["input_accepts"] else None
+            if "parameters" in data:
+                skill.parameters = json.dumps(data["parameters"])
+
+            skill.updated_at = datetime.utcnow()
+
+            # Regenerate definition
+            row_data = {
+                "id": skill.id,
+                "schema_version": skill.schema_version,
+                "name": skill.name,
+                "description": skill.description,
+                "icon": skill.icon,
+                "logo": skill.logo,
+                "version": skill.version,
+                "category": skill.category,
+                "tags": skill.tags,
+                "author_name": skill.author_name,
+                "author_url": skill.author_url,
+                "input_type": skill.input_type,
+                "input_accepts": skill.input_accepts,
+                "parameters": skill.parameters,
+                "prompt_system": skill.prompt_system,
+                "prompt_user_template": skill.prompt_user_template,
+                "output_format": skill.output_format,
+                "triggers": skill.triggers,
+            }
+            skill.definition = generate_skill_json(row_data)
+
+            session.commit()
+            session.refresh(skill)
+            return _skill_to_full_dict(skill)
+
+    return await run_sync(_update)
+
+
+async def delete_user_skill(skill_id: str) -> str:
+    """Delete a user skill and its executions. Returns 'deleted', 'not_found', or 'builtin_protected'."""
+    def _delete():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return "not_found"
+            if skill.source != "user":
+                return "builtin_protected"
+
+            # Mark any running executions as failed before deletion
+            session.execute(
+                update(SkillExecution)
+                .where(SkillExecution.skill_id == skill_id)
+                .where(SkillExecution.status == "running")
+                .values(status="failed", error="Skill deleted", completed_at=datetime.utcnow())
+            )
+
+            session.delete(skill)
+            session.commit()
+            return "deleted"
+
+    return await run_sync(_delete)
+
+
+async def get_skill_execution_history(
+    skill_id: str | None = None,
+    memory_id: int | None = None,
+    status: str | None = None,
+    search: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> tuple[list[dict], int]:
+    """Get execution history with pagination and filters. Returns (executions, total)."""
+    def _get():
+        with get_session_maker()() as session:
+            # Base query with JOINs
+            base = (
+                select(
+                    SkillExecution,
+                    Skill.name.label("skill_name"),
+                    Skill.icon.label("skill_icon"),
+                    Skill.logo.label("skill_logo"),
+                    Memory.title.label("memory_title"),
+                    Memory.type.label("memory_type"),
+                )
+                .join(Skill, SkillExecution.skill_id == Skill.id)
+                .join(Memory, SkillExecution.memory_id == Memory.id)
+            )
+
+            # Apply filters
+            if skill_id:
+                base = base.where(SkillExecution.skill_id == skill_id)
+            if memory_id:
+                base = base.where(SkillExecution.memory_id == memory_id)
+            if status:
+                base = base.where(SkillExecution.status == status)
+            if search:
+                base = base.where(Memory.title.ilike(f"%{search}%"))
+
+            # Count total
+            count_query = select(sa_func.count()).select_from(base.subquery())
+            total = session.execute(count_query).scalar() or 0
+
+            # Paginated results
+            query = base.order_by(SkillExecution.created_at.desc()).offset(offset).limit(limit)
+            results = session.execute(query).all()
+
+            executions = []
+            for ex, skill_name, skill_icon, skill_logo, memory_title, memory_type in results:
+                duration = None
+                if ex.started_at and ex.completed_at:
+                    duration = round((ex.completed_at - ex.started_at).total_seconds(), 1)
+
+                executions.append({
+                    "id": ex.id,
+                    "skill_id": ex.skill_id,
+                    "skill_name": skill_name,
+                    "skill_icon": skill_icon,
+                    "skill_logo": skill_logo,
+                    "memory_id": ex.memory_id,
+                    "memory_title": memory_title,
+                    "memory_type": memory_type,
+                    "trigger_type": ex.trigger_type,
+                    "parameters": json.loads(ex.parameters) if ex.parameters else None,
+                    "status": ex.status,
+                    "result": ex.result,
+                    "error": ex.error,
+                    "duration_seconds": duration,
+                    "started_at": ex.started_at.isoformat() if ex.started_at else None,
+                    "completed_at": ex.completed_at.isoformat() if ex.completed_at else None,
+                    "created_at": ex.created_at.isoformat() if ex.created_at else None,
+                })
+
+            return executions, total
+
+    return await run_sync(_get)
+
+
+async def get_skill_stats(skill_id: str) -> dict:
+    """Get aggregated execution stats for a skill."""
+    def _get():
+        with get_session_maker()() as session:
+            result = session.execute(
+                select(
+                    sa_func.count(SkillExecution.id).label("execution_count"),
+                    sa_func.sum(
+                        sa_func.case(
+                            (SkillExecution.status == "completed", 1),
+                            else_=0,
+                        )
+                    ).label("success_count"),
+                    sa_func.max(SkillExecution.started_at).label("last_executed_at"),
+                )
+                .where(SkillExecution.skill_id == skill_id)
+            ).first()
+
+            return {
+                "execution_count": result.execution_count or 0,
+                "success_count": result.success_count or 0,
+                "last_executed_at": result.last_executed_at.isoformat() if result.last_executed_at else None,
+            }
+
+    return await run_sync(_get)
+
+
+async def get_skill_raw(skill_id: str) -> dict | None:
+    """Get all columns of a skill as raw values (for export)."""
+    def _get():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return None
+            return {
+                "id": skill.id,
+                "schema_version": skill.schema_version,
+                "name": skill.name,
+                "description": skill.description,
+                "icon": skill.icon,
+                "logo": skill.logo,
+                "version": skill.version,
+                "category": skill.category,
+                "tags": skill.tags,
+                "author_name": skill.author_name,
+                "author_url": skill.author_url,
+                "input_type": skill.input_type,
+                "input_accepts": skill.input_accepts,
+                "parameters": skill.parameters,
+                "prompt_system": skill.prompt_system,
+                "prompt_user_template": skill.prompt_user_template,
+                "output_format": skill.output_format,
+                "triggers": skill.triggers,
+                "source": skill.source,
+                "hidden": skill.hidden,
+                "definition": skill.definition,
+                "created_at": skill.created_at,
+                "updated_at": skill.updated_at,
+            }
+
+    return await run_sync(_get)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Trigger CRUD
+# ---------------------------------------------------------------------------
+
+def _trigger_to_dict(trigger: SkillTrigger) -> dict:
+    """Convert a SkillTrigger ORM object to a dict."""
+    return {
+        "id": trigger.id,
+        "skill_id": trigger.skill_id,
+        "name": trigger.name,
+        "description": trigger.description,
+        "enabled": bool(trigger.enabled),
+        "event_type": trigger.event_type,
+        "conditions": json.loads(trigger.conditions),
+        "parameters": json.loads(trigger.parameters) if trigger.parameters else None,
+        "execution_count": trigger.execution_count,
+        "last_triggered_at": trigger.last_triggered_at.isoformat() if trigger.last_triggered_at else None,
+        "created_at": trigger.created_at.isoformat() if trigger.created_at else None,
+        "updated_at": trigger.updated_at.isoformat() if trigger.updated_at else None,
+    }
+
+
+async def get_skill_triggers(skill_id: str) -> list[dict]:
+    """Get all triggers for a skill."""
+    def _get():
+        with get_session_maker()() as session:
+            triggers = session.execute(
+                select(SkillTrigger)
+                .where(SkillTrigger.skill_id == skill_id)
+                .order_by(SkillTrigger.created_at.desc())
+            ).scalars().all()
+            return [_trigger_to_dict(t) for t in triggers]
+
+    return await run_sync(_get)
+
+
+async def get_enabled_triggers() -> list[dict]:
+    """Get all enabled triggers with skill info (for evaluator)."""
+    def _get():
+        with get_session_maker()() as session:
+            results = session.execute(
+                select(SkillTrigger, Skill.name.label("skill_name"), Skill.icon.label("skill_icon"))
+                .join(Skill, SkillTrigger.skill_id == Skill.id)
+                .where(SkillTrigger.enabled == True)  # noqa: E712
+            ).all()
+            return [
+                {**_trigger_to_dict(t), "skill_name": skill_name, "skill_icon": skill_icon}
+                for t, skill_name, skill_icon in results
+            ]
+
+    return await run_sync(_get)
+
+
+async def create_trigger(skill_id: str, data: dict) -> dict | None:
+    """Create a new trigger. Returns None if skill not found."""
+    def _create():
+        with get_session_maker()() as session:
+            skill = session.get(Skill, skill_id)
+            if not skill:
+                return None
+            trigger = SkillTrigger(
+                skill_id=skill_id,
+                name=data["name"],
+                description=data.get("description"),
+                event_type=data.get("event_type", "on_save"),
+                conditions=json.dumps(data["conditions"]),
+                parameters=json.dumps(data["parameters"]) if data.get("parameters") else None,
+            )
+            session.add(trigger)
+            session.commit()
+            session.refresh(trigger)
+            return _trigger_to_dict(trigger)
+
+    return await run_sync(_create)
+
+
+async def update_trigger(trigger_id: int, data: dict) -> dict | None:
+    """Update a trigger. Returns None if not found."""
+    def _update():
+        with get_session_maker()() as session:
+            trigger = session.get(SkillTrigger, trigger_id)
+            if not trigger:
+                return None
+            if "name" in data:
+                trigger.name = data["name"]
+            if "description" in data:
+                trigger.description = data["description"]
+            if "conditions" in data:
+                trigger.conditions = json.dumps(data["conditions"])
+            if "parameters" in data:
+                trigger.parameters = json.dumps(data["parameters"]) if data["parameters"] else None
+            if "enabled" in data:
+                trigger.enabled = data["enabled"]
+            trigger.updated_at = datetime.utcnow()
+            session.commit()
+            session.refresh(trigger)
+            return _trigger_to_dict(trigger)
+
+    return await run_sync(_update)
+
+
+async def delete_trigger(trigger_id: int) -> bool:
+    """Delete a trigger. Returns False if not found."""
+    def _delete():
+        with get_session_maker()() as session:
+            trigger = session.get(SkillTrigger, trigger_id)
+            if not trigger:
+                return False
+            session.delete(trigger)
+            session.commit()
+            return True
+
+    return await run_sync(_delete)
+
+
+async def toggle_trigger(trigger_id: int, enabled: bool) -> dict | None:
+    """Toggle a trigger's enabled status. Returns None if not found."""
+    def _toggle():
+        with get_session_maker()() as session:
+            trigger = session.get(SkillTrigger, trigger_id)
+            if not trigger:
+                return None
+            trigger.enabled = enabled
+            trigger.updated_at = datetime.utcnow()
+            session.commit()
+            session.refresh(trigger)
+            return _trigger_to_dict(trigger)
+
+    return await run_sync(_toggle)
+
+
+async def update_trigger_stats(trigger_id: int) -> None:
+    """Increment execution_count and update last_triggered_at."""
+    def _update():
+        with get_session_maker()() as session:
+            trigger = session.get(SkillTrigger, trigger_id)
+            if trigger:
+                trigger.execution_count += 1
+                trigger.last_triggered_at = datetime.utcnow()
+                session.commit()
+
+    await run_sync(_update)
+
+
+async def get_matching_memories(conditions: dict, limit: int = 10) -> tuple[list[dict], int, int]:
+    """Evaluate conditions against all memories for preview. Returns (matching, match_count, total)."""
+    def _get():
+        with get_session_maker()() as session:
+            from ...services.skills.triggers import evaluate_conditions
+
+            all_memories = session.execute(
+                select(Memory).order_by(Memory.created_at.desc())
+            ).scalars().all()
+            total = len(all_memories)
+
+            # Batch-load tags
+            tags_by_memory: dict[int, list[dict]] = {}
+            if all_memories:
+                memory_ids = [m.id for m in all_memories]
+                all_tags = session.execute(
+                    select(MemoryTag, Tag)
+                    .join(Tag, MemoryTag.tag_id == Tag.id)
+                    .where(MemoryTag.memory_id.in_(memory_ids))
+                ).all()
+                for mt, tag in all_tags:
+                    tags_by_memory.setdefault(mt.memory_id, []).append(
+                        {"id": tag.id, "name": tag.name, "source": mt.source}
+                    )
+
+            matching = []
+            for m in all_memories:
+                mem_dict = {
+                    "id": m.id, "type": m.type, "title": m.title, "url": m.url,
+                    "content": m.content, "tags": tags_by_memory.get(m.id, []),
+                    "transcript": m.transcript, "media_source": m.media_source,
+                }
+                if evaluate_conditions(conditions, mem_dict):
+                    matching.append({
+                        "id": m.id,
+                        "title": m.title,
+                        "type": m.type,
+                        "tags": [t["name"] for t in tags_by_memory.get(m.id, [])],
+                    })
+
+            return matching[:limit], len(matching), total
+
+    return await run_sync(_get)
+
+
+async def get_skills_with_chat_triggers() -> list[dict]:
+    """Get all non-hidden skills that have chat trigger patterns defined."""
+    def _get():
+        with get_session_maker()() as session:
+            skills = session.execute(
+                select(Skill)
+                .where(Skill.hidden == False)  # noqa: E712
+                .where(Skill.triggers.isnot(None))
+                .order_by(Skill.name)
+            ).scalars().all()
+
+            result = []
+            for s in skills:
+                triggers = json.loads(s.triggers) if s.triggers else {}
+                if "chat" not in triggers:
+                    continue
+                result.append({
+                    "id": s.id,
+                    "name": s.name,
+                    "icon": s.icon,
+                    "input_accepts": s.input_accepts,
+                    "triggers": s.triggers,
+                })
+            return result
+
+    return await run_sync(_get)

--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -609,6 +609,124 @@ def migration_019(conn: Connection) -> None:
         ))
 
 
+@migration(20, "Create skills and skill_executions tables")
+def migration_020(conn: Connection) -> None:
+    """Create tables for the Skill System Phase 1.
+
+    - skills: Stores skill definitions (built-in and user-created)
+    - skill_executions: Tracks each skill execution with result
+    """
+    # --- skills table ---
+    result = conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skills'"
+    )).fetchone()
+
+    if not result:
+        conn.execute(text("""
+            CREATE TABLE skills (
+                id TEXT PRIMARY KEY,
+                schema_version INTEGER NOT NULL DEFAULT 1,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL,
+                icon TEXT NOT NULL,
+                logo TEXT,
+                version TEXT NOT NULL,
+                category TEXT NOT NULL DEFAULT 'custom',
+                tags TEXT,
+                author_name TEXT,
+                author_url TEXT,
+                input_type TEXT NOT NULL DEFAULT 'single_memory',
+                input_accepts TEXT,
+                parameters TEXT,
+                prompt_system TEXT NOT NULL,
+                prompt_user_template TEXT NOT NULL,
+                output_format TEXT NOT NULL DEFAULT 'markdown',
+                triggers TEXT,
+                source TEXT NOT NULL,
+                hidden BOOLEAN NOT NULL DEFAULT 0,
+                definition TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """))
+
+    # --- skill_executions table ---
+    result = conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_executions'"
+    )).fetchone()
+
+    if not result:
+        conn.execute(text("""
+            CREATE TABLE skill_executions (
+                id INTEGER PRIMARY KEY,
+                skill_id TEXT NOT NULL,
+                memory_id INTEGER NOT NULL,
+                trigger_type TEXT NOT NULL,
+                parameters TEXT,
+                status TEXT NOT NULL,
+                result TEXT,
+                error TEXT,
+                started_at TIMESTAMP,
+                completed_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE,
+                FOREIGN KEY (memory_id) REFERENCES memories(id) ON DELETE CASCADE
+            )
+        """))
+
+        conn.execute(text(
+            "CREATE INDEX idx_skill_executions_skill_id ON skill_executions(skill_id)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX idx_skill_executions_memory_id ON skill_executions(memory_id)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX idx_skill_executions_created_at ON skill_executions(created_at DESC)"
+        ))
+
+
+@migration(21, "Create skill_triggers table for automation")
+def migration_021(conn: Connection) -> None:
+    """Create skill_triggers table for trigger-engine (Phase 3)."""
+    result = conn.execute(text(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_triggers'"
+    )).fetchone()
+
+    if not result:
+        conn.execute(text("""
+            CREATE TABLE skill_triggers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                skill_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT,
+                enabled BOOLEAN NOT NULL DEFAULT 1,
+                event_type TEXT NOT NULL DEFAULT 'on_save',
+                conditions TEXT NOT NULL,
+                parameters TEXT,
+                execution_count INTEGER NOT NULL DEFAULT 0,
+                last_triggered_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+            )
+        """))
+        conn.execute(text(
+            "CREATE INDEX idx_skill_triggers_skill_id ON skill_triggers(skill_id)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX idx_skill_triggers_enabled ON skill_triggers(enabled)"
+        ))
+
+
+@migration(22, "Add metadata column to messages for skill execution tracking")
+def migration_022(conn: Connection) -> None:
+    """Add metadata column to messages table for chat skill execution."""
+    result = conn.execute(text("PRAGMA table_info(messages)")).fetchall()
+    columns = [row[1] for row in result]
+    if "metadata" not in columns:
+        conn.execute(text("ALTER TABLE messages ADD COLUMN metadata TEXT"))
+
+
 # --- Migration runner ---
 
 def run_migrations(conn: Connection) -> list[tuple[int, str]]:

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -14,6 +14,8 @@ class EventType(str, Enum):
     MEMORY_CREATED = "memory_created"
     MEMORY_UPDATED = "memory_updated"
     MEMORY_DELETED = "memory_deleted"
+    MEMORY_PROCESSED = "memory_processed"
+    SKILL_EXECUTED = "skill_executed"
     CONVERSATION_CREATED = "conversation_created"
     CONVERSATION_UPDATED = "conversation_updated"
     CONVERSATION_DELETED = "conversation_deleted"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -100,6 +100,7 @@ class Message(Base):
     prompt_tokens: Mapped[int | None] = mapped_column(nullable=True)
     completion_tokens: Mapped[int | None] = mapped_column(nullable=True)
     total_tokens: Mapped[int | None] = mapped_column(nullable=True)
+    msg_metadata: Mapped[str | None] = mapped_column("metadata", Text, nullable=True)  # JSON: skill execution metadata
 
     conversation: Mapped["Conversation"] = relationship(back_populates="messages")
     sources: Mapped[list["MessageSource"]] = relationship(back_populates="message", cascade="all, delete-orphan")
@@ -147,3 +148,64 @@ class MemoryLink(Base):
 
     source_memory: Mapped["Memory"] = relationship(foreign_keys=[source_memory_id])
     target_memory: Mapped["Memory"] = relationship(foreign_keys=[target_memory_id])
+
+
+class Skill(Base):
+    __tablename__ = "skills"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    schema_version: Mapped[int] = mapped_column(default=1)
+    name: Mapped[str] = mapped_column(String(60))
+    description: Mapped[str] = mapped_column(String(200))
+    icon: Mapped[str] = mapped_column(String(10))
+    logo: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[str] = mapped_column(String(20))
+    category: Mapped[str] = mapped_column(String(20), default="custom")
+    tags: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON array
+    author_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    author_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    input_type: Mapped[str] = mapped_column(String(20), default="single_memory")
+    input_accepts: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON array
+    parameters: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON array
+    prompt_system: Mapped[str] = mapped_column(Text)
+    prompt_user_template: Mapped[str] = mapped_column(Text)
+    output_format: Mapped[str] = mapped_column(String(20), default="markdown")
+    triggers: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON, Phase 1 ignored
+    source: Mapped[str] = mapped_column(String(10))  # "builtin" | "user"
+    hidden: Mapped[bool] = mapped_column(default=False)
+    definition: Mapped[str] = mapped_column(Text)  # Raw .think-skill JSON
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class SkillExecution(Base):
+    __tablename__ = "skill_executions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    skill_id: Mapped[str] = mapped_column(ForeignKey("skills.id", ondelete="CASCADE"))
+    memory_id: Mapped[int] = mapped_column(ForeignKey("memories.id", ondelete="CASCADE"))
+    trigger_type: Mapped[str] = mapped_column(String(20))  # Phase 1: always "manual"
+    parameters: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON
+    status: Mapped[str] = mapped_column(String(20))  # "running" | "completed" | "failed"
+    result: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class SkillTrigger(Base):
+    __tablename__ = "skill_triggers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    skill_id: Mapped[str] = mapped_column(ForeignKey("skills.id", ondelete="CASCADE"))
+    name: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    enabled: Mapped[bool] = mapped_column(default=True)
+    event_type: Mapped[str] = mapped_column(String(20), default="on_save")
+    conditions: Mapped[str] = mapped_column(Text)  # JSON
+    parameters: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON
+    execution_count: Mapped[int] = mapped_column(Integer, default=0)
+    last_triggered_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -13,6 +13,7 @@ from .links import router as links_router
 from .graph import router as graph_router
 from .analytics import router as analytics_router
 from .insights import router as insights_router
+from .skills import router as skills_router
 
 router = APIRouter()
 router.include_router(auth_router)
@@ -28,3 +29,4 @@ router.include_router(links_router)
 router.include_router(graph_router)
 router.include_router(analytics_router)
 router.include_router(insights_router)
+router.include_router(skills_router)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -36,6 +36,10 @@ async def setup_password(request: SetPasswordRequest):
     set_video_encryption_key(request.password)
     set_document_encryption_key(request.password)
 
+    # Start trigger evaluator
+    from ..services.skills.triggers import trigger_evaluator
+    await trigger_evaluator.start()
+
     return {"success": True}
 
 
@@ -58,12 +62,20 @@ async def unlock(request: UnlockRequest):
     set_video_encryption_key(request.password)
     set_document_encryption_key(request.password)
 
+    # Start trigger evaluator
+    from ..services.skills.triggers import trigger_evaluator
+    await trigger_evaluator.start()
+
     return {"success": True}
 
 
 @router.post("/auth/logout")
 async def logout():
     """Lock the database (logout)."""
+    # Stop trigger evaluator before closing DB
+    from ..services.skills.triggers import trigger_evaluator
+    await trigger_evaluator.stop()
+
     reset_db_connection()
     # Clear media encryption keys
     clear_audio_encryption_key()

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -16,10 +16,13 @@ from ..services.ai.suggestions import get_quick_prompts, generate_followup_sugge
 from ..services.query.special_handlers import is_special_prompt, execute_special_handler
 from ..services.embeddings.filtering import filter_memories_dynamically, format_memories_as_context, compute_context_budget
 from ..db.search import search_similar_memories
+from pydantic import BaseModel
 from ..schemas import ChatRequest
 from .. import config
 from ..db.crud import create_conversation, add_message, update_conversation_title, get_conversation, get_memory
 from ..events import event_manager, MemoryEvent, EventType
+from ..services.skills.chat_suggestions import detect_skill_suggestions
+from ..services.skills.executor import execute_skill
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +85,7 @@ async def _retrieve_context(
                     "id": memory["id"],
                     "title": memory["title"],
                     "url": memory.get("url"),
+                    "type": memory.get("type"),
                 })
 
         if attached_memories:
@@ -140,6 +144,7 @@ async def _retrieve_context(
                             "id": m["id"],
                             "title": m["title"],
                             "url": m.get("url"),
+                            "type": m.get("type"),
                             "distance": m.get("distance"),
                             "match_type": m.get("match_type", "vector"),
                             "rrf_score": m.get("rrf_score"),
@@ -295,12 +300,15 @@ async def chat_stream(request: ChatRequest):
     # RAG: Retrieve relevant memories
     context, sources = await _retrieve_context(request.message, history, request.attached_memory_ids, skip_rag=request.skip_memory_context)
 
+    # Detect skill suggestions based on message patterns and context
+    skill_suggestions = await detect_skill_suggestions(request.message, sources)
+
     async def generate():
         full_response = ""
         usage_data = None
 
-        # Send metadata first (conversation_id, sources)
-        yield f"data: {json.dumps({'type': 'meta', 'conversation_id': conversation_id, 'sources': sources, 'searched': not request.skip_memory_context})}\n\n"
+        # Send metadata first (conversation_id, sources, skill suggestions)
+        yield f"data: {json.dumps({'type': 'meta', 'conversation_id': conversation_id, 'sources': sources, 'searched': not request.skip_memory_context, 'skill_suggestions': skill_suggestions})}\n\n"
 
         try:
             async for token, usage in ai_chat_stream(request.message, context=context, history=history):
@@ -352,4 +360,69 @@ async def chat_stream(request: ChatRequest):
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
         }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chat Skill Execution
+# ---------------------------------------------------------------------------
+
+class ChatSkillExecuteRequest(BaseModel):
+    conversation_id: int
+    skill_id: str
+    memory_id: int
+    parameters: dict | None = None
+
+
+@router.post("/chat/execute-skill")
+async def chat_execute_skill(request: ChatSkillExecuteRequest):
+    """Execute a skill from chat context. Creates execution record and saves result as chat message."""
+    conversation = await get_conversation(request.conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    async def generate():
+        full_result = ""
+        execution_id = None
+        skill_name = None
+        skill_icon = None
+
+        async for event in execute_skill(
+            skill_id=request.skill_id,
+            memory_id=request.memory_id,
+            parameters=request.parameters,
+            trigger_type="chat",
+        ):
+            # Capture metadata from meta event
+            if event.get("type") == "meta" and "content_source" in event:
+                execution_id = event.get("execution_id")
+                skill_name = event.get("skill_name")
+
+            if event.get("type") == "token":
+                full_result += event["content"]
+
+            if event.get("type") == "done":
+                # Save as chat message with metadata
+                metadata = json.dumps({
+                    "skill_execution_id": execution_id,
+                    "skill_id": request.skill_id,
+                    "skill_name": skill_name,
+                    "memory_id": request.memory_id,
+                })
+                await add_message(
+                    request.conversation_id,
+                    "assistant",
+                    full_result,
+                    metadata=metadata,
+                )
+
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
     )

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1,0 +1,499 @@
+import json
+import logging
+import uuid as uuid_mod
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse, Response
+from pydantic import BaseModel
+
+from ..db.crud.skills import (
+    get_skill,
+    get_skill_raw,
+    get_all_skills,
+    toggle_skill_visibility,
+    get_skill_executions,
+    get_skill_execution_history,
+    create_user_skill,
+    update_user_skill,
+    delete_user_skill,
+    get_skill_triggers,
+    create_trigger,
+    update_trigger,
+    delete_trigger,
+    toggle_trigger,
+    get_matching_memories,
+)
+from ..services.skills.executor import execute_skill, test_execute
+from ..services.skills.registry import validate_skill_json, generate_skill_json
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["skills"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Request Models
+# ---------------------------------------------------------------------------
+
+class SkillExecuteRequest(BaseModel):
+    skill_id: str
+    memory_id: int
+    parameters: dict | None = None
+
+
+class SkillVisibilityRequest(BaseModel):
+    hidden: bool
+
+
+class SkillCreateRequest(BaseModel):
+    name: str
+    description: str
+    icon: str
+    category: str = "custom"
+    tags: list[str] = []
+    input_type: str = "single_memory"
+    input_accepts: list[str] | None = None
+    parameters: list[dict] = []
+    prompt_system: str
+    prompt_user_template: str
+    output_format: str = "markdown"
+    author_name: str | None = None
+    author_url: str | None = None
+    logo: str | None = None
+
+
+class SkillUpdateRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    logo: str | None = None
+    category: str | None = None
+    tags: list[str] | None = None
+    input_type: str | None = None
+    input_accepts: list[str] | None = None
+    parameters: list[dict] | None = None
+    prompt_system: str | None = None
+    prompt_user_template: str | None = None
+    output_format: str | None = None
+    author_name: str | None = None
+    author_url: str | None = None
+
+
+class SkillTestRequest(BaseModel):
+    memory_id: int
+    prompt_system: str
+    prompt_user_template: str
+    parameters: list[dict] | None = None
+    parameter_values: dict | None = None
+    input_accepts: list[str] | None = None
+    output_format: str = "markdown"
+
+
+class SkillValidateRequest(BaseModel):
+    definition: str
+
+
+class SkillImportRequest(BaseModel):
+    definition: str
+    conflict_resolution: str = "copy"  # "copy" or "replace"
+
+
+class TriggerCreateRequest(BaseModel):
+    name: str
+    description: str | None = None
+    event_type: str = "on_save"
+    conditions: dict
+    parameters: dict | None = None
+
+
+class TriggerUpdateRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    conditions: dict | None = None
+    parameters: dict | None = None
+    enabled: bool | None = None
+
+
+class TriggerToggleRequest(BaseModel):
+    enabled: bool
+
+
+class TriggerPreviewRequest(BaseModel):
+    conditions: dict
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parsed_to_crud_data(parsed: dict) -> dict:
+    """Convert parsed .think-skill JSON to CRUD data dict."""
+    prompt = parsed.get("prompt", {})
+    input_config = parsed.get("input", {})
+    author = parsed.get("author", {})
+    return {
+        "id": parsed.get("id"),
+        "name": parsed["name"],
+        "description": parsed["description"],
+        "icon": parsed["icon"],
+        "logo": parsed.get("logo"),
+        "version": parsed.get("version", "1.0.0"),
+        "category": parsed.get("category", "custom"),
+        "tags": parsed.get("tags", []),
+        "author_name": author.get("name") if author else None,
+        "author_url": author.get("url") if author else None,
+        "input_type": input_config.get("type", "single_memory"),
+        "input_accepts": input_config.get("accepts"),
+        "parameters": parsed.get("parameters", []),
+        "prompt_system": prompt["system"],
+        "prompt_user_template": prompt["user_template"],
+        "output_format": parsed.get("output", {}).get("format", "markdown"),
+        "triggers": parsed.get("triggers"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes — Fixed paths MUST come before /skills/{skill_id}
+# ---------------------------------------------------------------------------
+
+@router.get("/skills")
+async def list_skills(
+    include_hidden: bool = Query(False),
+    source: str | None = Query(None),
+    category: str | None = Query(None),
+    search: str | None = Query(None),
+):
+    """Get all skills with optional filtering."""
+    return await get_all_skills(
+        include_hidden=include_hidden,
+        source_filter=source,
+        category_filter=category,
+        search=search,
+    )
+
+
+@router.get("/skills/executions")
+async def list_executions(
+    memory_id: int | None = Query(None),
+    skill_id: str | None = Query(None),
+    status: str | None = Query(None),
+    search: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """Get execution history with pagination and filters."""
+    # Backwards compatibility: if only memory_id given, use the simple function
+    if memory_id and not skill_id and not status and not search and limit == 20 and offset == 0:
+        return await get_skill_executions(memory_id)
+
+    executions, total = await get_skill_execution_history(
+        skill_id=skill_id,
+        memory_id=memory_id,
+        status=status,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "executions": executions,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.post("/skills/execute")
+async def execute_skill_endpoint(request: SkillExecuteRequest):
+    """Execute a skill against a memory. Returns SSE stream."""
+
+    async def generate():
+        async for event in execute_skill(
+            skill_id=request.skill_id,
+            memory_id=request.memory_id,
+            parameters=request.parameters,
+        ):
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.post("/skills/test")
+async def test_skill_endpoint(request: SkillTestRequest):
+    """Test-run a skill without DB tracking. Returns SSE stream."""
+
+    async def generate():
+        async for event in test_execute(
+            memory_id=request.memory_id,
+            prompt_system=request.prompt_system,
+            prompt_user_template=request.prompt_user_template,
+            parameters_def=request.parameters,
+            parameter_values=request.parameter_values,
+            input_accepts=request.input_accepts,
+            output_format=request.output_format,
+        ):
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.post("/skills/validate")
+async def validate_skill_endpoint(request: SkillValidateRequest):
+    """Validate a .think-skill JSON string."""
+    valid, errors, warnings, parsed = validate_skill_json(request.definition)
+
+    if valid:
+        return {
+            "valid": True,
+            "warnings": warnings,
+            "parsed": {"name": parsed.get("name"), "id": parsed.get("id")} if parsed else None,
+        }
+    return {
+        "valid": False,
+        "errors": errors,
+        "warnings": warnings,
+        "parsed": None,
+    }
+
+
+@router.post("/skills/import")
+async def import_skill(request: SkillImportRequest):
+    """Import a .think-skill file."""
+    # 1. Validate
+    valid, errors, warnings, parsed = validate_skill_json(request.definition)
+    if not valid:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Invalid skill definition", "errors": errors},
+        )
+
+    skill_id = parsed["id"]
+
+    # 2. Check for ID collision
+    existing = await get_skill(skill_id)
+
+    if existing:
+        if request.conflict_resolution == "replace":
+            existing_raw = await get_skill_raw(skill_id)
+            if existing_raw and existing_raw["source"] != "user":
+                raise HTTPException(
+                    status_code=403,
+                    detail="Cannot replace a built-in skill. Use 'copy' instead.",
+                )
+            import_data = _parsed_to_crud_data(parsed)
+            result = await update_user_skill(skill_id, import_data)
+            return result
+        else:
+            # "copy" - generate new UUID
+            parsed["id"] = str(uuid_mod.uuid4())
+
+    # 3. Create the skill
+    import_data = _parsed_to_crud_data(parsed)
+    result = await create_user_skill(import_data)
+    return result
+
+
+@router.post("/skills/triggers/preview")
+async def preview_trigger(request: TriggerPreviewRequest):
+    """Preview which existing memories would match the given conditions."""
+    if "rules" not in request.conditions:
+        raise HTTPException(400, "conditions must contain 'rules'")
+
+    matching, match_count, total = await get_matching_memories(request.conditions)
+    return {
+        "matching_count": match_count,
+        "matching_memories": matching,
+        "total_memories": total,
+    }
+
+
+@router.post("/skills")
+async def create_skill(request: SkillCreateRequest):
+    """Create a new user skill."""
+    # Validation
+    if not request.name.strip():
+        raise HTTPException(400, "name cannot be empty")
+    if len(request.name) > 60:
+        raise HTTPException(400, "name must be 60 characters or less")
+    if not request.description.strip():
+        raise HTTPException(400, "description cannot be empty")
+    if len(request.description) > 200:
+        raise HTTPException(400, "description must be 200 characters or less")
+    if not request.prompt_system.strip():
+        raise HTTPException(400, "prompt_system cannot be empty")
+    if "{{content}}" not in request.prompt_user_template:
+        raise HTTPException(400, "prompt_user_template must contain {{content}}")
+    if request.logo and len(request.logo.encode("utf-8")) > 32 * 1024:
+        raise HTTPException(400, "logo exceeds 32KB limit")
+
+    return await create_user_skill(request.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Routes with {skill_id} — MUST come after fixed paths
+# ---------------------------------------------------------------------------
+
+@router.get("/skills/{skill_id}")
+async def get_skill_detail(skill_id: str):
+    """Get a single skill with prompt details and triggers."""
+    skill = await get_skill(skill_id)
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    skill["triggers"] = await get_skill_triggers(skill_id)
+    return skill
+
+
+@router.put("/skills/{skill_id}")
+async def update_skill(skill_id: str, request: SkillUpdateRequest):
+    """Update a user skill (only source='user' skills can be updated)."""
+    data = request.model_dump(exclude_unset=True)
+
+    if "name" in data and data["name"] is not None:
+        if not data["name"].strip():
+            raise HTTPException(400, "name cannot be empty")
+        if len(data["name"]) > 60:
+            raise HTTPException(400, "name must be 60 characters or less")
+
+    if "description" in data and data["description"] is not None:
+        if not data["description"].strip():
+            raise HTTPException(400, "description cannot be empty")
+        if len(data["description"]) > 200:
+            raise HTTPException(400, "description must be 200 characters or less")
+
+    if "prompt_user_template" in data and data["prompt_user_template"] is not None:
+        if "{{content}}" not in data["prompt_user_template"]:
+            raise HTTPException(400, "prompt_user_template must contain {{content}}")
+    if "logo" in data and data["logo"] is not None:
+        if len(data["logo"].encode("utf-8")) > 32 * 1024:
+            raise HTTPException(400, "logo exceeds 32KB limit")
+
+    result = await update_user_skill(skill_id, data)
+    if result is None:
+        raise HTTPException(404, "Skill not found")
+    if result == "builtin_protected":
+        raise HTTPException(403, "Built-in skills cannot be edited")
+    return result
+
+
+@router.delete("/skills/{skill_id}")
+async def delete_skill(skill_id: str):
+    """Delete a user skill and its execution history."""
+    result = await delete_user_skill(skill_id)
+    if result == "not_found":
+        raise HTTPException(404, "Skill not found")
+    if result == "builtin_protected":
+        raise HTTPException(403, "Built-in skills cannot be deleted")
+    return {"deleted": True}
+
+
+@router.get("/skills/{skill_id}/export")
+async def export_skill(skill_id: str):
+    """Export a skill as .think-skill JSON."""
+    skill_raw = await get_skill_raw(skill_id)
+    if not skill_raw:
+        raise HTTPException(404, "Skill not found")
+
+    # Built-in: return original definition. User: regenerate from DB columns.
+    if skill_raw["source"] == "builtin" and skill_raw.get("definition"):
+        json_content = skill_raw["definition"]
+    else:
+        json_content = generate_skill_json(skill_raw)
+
+    # Slugify name for filename
+    safe_name = skill_raw["name"].lower().replace(" ", "-")
+    safe_name = "".join(c for c in safe_name if c.isalnum() or c == "-")
+
+    return Response(
+        content=json_content,
+        media_type="application/json",
+        headers={
+            "Content-Disposition": f'attachment; filename="{safe_name}.think-skill"',
+        },
+    )
+
+
+@router.patch("/skills/{skill_id}/visibility")
+async def update_skill_visibility(skill_id: str, body: SkillVisibilityRequest):
+    """Toggle a skill's hidden status."""
+    success = await toggle_skill_visibility(skill_id, body.hidden)
+    if not success:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Trigger Routes
+# ---------------------------------------------------------------------------
+
+@router.get("/skills/{skill_id}/triggers")
+async def list_triggers(skill_id: str):
+    """Get all triggers for a skill."""
+    skill = await get_skill(skill_id)
+    if not skill:
+        raise HTTPException(404, "Skill not found")
+    return await get_skill_triggers(skill_id)
+
+
+@router.post("/skills/{skill_id}/triggers")
+async def create_trigger_endpoint(skill_id: str, request: TriggerCreateRequest):
+    """Create a new trigger for a skill."""
+    if not request.name.strip():
+        raise HTTPException(400, "name cannot be empty")
+    if len(request.name) > 200:
+        raise HTTPException(400, "name must be 200 characters or less")
+    if "rules" not in request.conditions:
+        raise HTTPException(400, "conditions must contain 'rules'")
+    if not request.conditions.get("rules"):
+        raise HTTPException(400, "conditions must have at least one rule")
+
+    result = await create_trigger(skill_id, request.model_dump())
+    if result is None:
+        raise HTTPException(404, "Skill not found")
+    return result
+
+
+@router.put("/skills/triggers/{trigger_id}")
+async def update_trigger_endpoint(trigger_id: int, request: TriggerUpdateRequest):
+    """Update a trigger."""
+    data = request.model_dump(exclude_unset=True)
+    if "name" in data and data["name"] is not None:
+        if not data["name"].strip():
+            raise HTTPException(400, "name cannot be empty")
+    if "conditions" in data and data["conditions"] is not None:
+        if "rules" not in data["conditions"]:
+            raise HTTPException(400, "conditions must contain 'rules'")
+
+    result = await update_trigger(trigger_id, data)
+    if result is None:
+        raise HTTPException(404, "Trigger not found")
+    return result
+
+
+@router.delete("/skills/triggers/{trigger_id}")
+async def delete_trigger_endpoint(trigger_id: int):
+    """Delete a trigger."""
+    success = await delete_trigger(trigger_id)
+    if not success:
+        raise HTTPException(404, "Trigger not found")
+    return {"deleted": True}
+
+
+@router.patch("/skills/triggers/{trigger_id}")
+async def toggle_trigger_endpoint(trigger_id: int, request: TriggerToggleRequest):
+    """Toggle a trigger's enabled status."""
+    result = await toggle_trigger(trigger_id, request.enabled)
+    if result is None:
+        raise HTTPException(404, "Trigger not found")
+    return result

--- a/backend/app/services/ai/processing.py
+++ b/backend/app/services/ai/processing.py
@@ -290,6 +290,15 @@ async def process_memory_async(memory_id: int) -> None:
             )
             logger.info(f"Emitted update event for memory {memory_id}")
 
+            # Fire MEMORY_PROCESSED event (for trigger evaluation)
+            await event_manager.publish(
+                MemoryEvent(
+                    type=EventType.MEMORY_PROCESSED,
+                    memory_id=memory_id,
+                    data=updated_memory,
+                )
+            )
+
     except Exception as e:
         logger.error(f"Failed to process memory {memory_id}: {e}")
 
@@ -531,6 +540,15 @@ async def process_voice_memory_async(memory_id: int) -> None:
         )
         logger.info(f"Emitted update event for voice memory {memory_id}")
 
+        # Fire MEMORY_PROCESSED event (for trigger evaluation)
+        await event_manager.publish(
+            MemoryEvent(
+                type=EventType.MEMORY_PROCESSED,
+                memory_id=memory_id,
+                data=updated_memory,
+            )
+        )
+
     except Exception as e:
         logger.error(f"Failed to process voice memory {memory_id}: {e}")
         # Set status to failed and notify frontend
@@ -677,6 +695,15 @@ async def process_document_memory_async(memory_id: int) -> None:
             )
         )
         logger.info(f"Emitted update event for document memory {memory_id}")
+
+        # Fire MEMORY_PROCESSED event (for trigger evaluation)
+        await event_manager.publish(
+            MemoryEvent(
+                type=EventType.MEMORY_PROCESSED,
+                memory_id=memory_id,
+                data=updated_memory,
+            )
+        )
 
     except Exception as e:
         logger.error(f"Failed to process document memory {memory_id}: {e}")

--- a/backend/app/services/skills/chat_suggestions.py
+++ b/backend/app/services/skills/chat_suggestions.py
@@ -1,0 +1,76 @@
+"""Chat-Integration: pattern-based skill suggestions for chat context."""
+
+import json
+import logging
+
+from ...db.crud.skills import get_skills_with_chat_triggers
+
+logger = logging.getLogger(__name__)
+
+
+async def detect_skill_suggestions(
+    message: str,
+    sources: list[dict],
+) -> list[dict]:
+    """Detect relevant skill suggestions based on chat message patterns and context memories.
+
+    Returns max 3 suggestions, each with:
+    skill_id, skill_name, skill_icon, memory_id, memory_title, auto_parameters,
+    match_reason, matched_pattern
+    """
+    if not sources:
+        return []
+
+    skills = await get_skills_with_chat_triggers()
+    if not skills:
+        return []
+
+    suggestions = []
+    message_lower = message.lower()
+
+    for skill in skills:
+        triggers = json.loads(skill["triggers"]) if isinstance(skill["triggers"], str) else skill["triggers"]
+        chat_config = triggers.get("chat")
+        if not chat_config:
+            continue
+
+        patterns = chat_config.get("patterns", [])
+        matched_pattern = None
+
+        for pattern in patterns:
+            if pattern.lower() in message_lower:
+                matched_pattern = pattern
+                break
+
+        if not matched_pattern:
+            continue
+
+        # Check input.accepts against source memories
+        accepts = json.loads(skill["input_accepts"]) if skill["input_accepts"] else None
+
+        for source in sources:
+            source_type = source.get("type")
+            if accepts and source_type and source_type not in accepts:
+                continue
+
+            suggestions.append({
+                "skill_id": skill["id"],
+                "skill_name": skill["name"],
+                "skill_icon": skill["icon"],
+                "memory_id": source["id"],
+                "memory_title": source.get("title", "Untitled"),
+                "auto_parameters": chat_config.get("auto_parameters", {}),
+                "match_reason": "pattern_match",
+                "matched_pattern": matched_pattern,
+            })
+
+    # Deduplicate: same skill + same memory = keep first
+    seen = set()
+    unique = []
+    for s in suggestions:
+        key = s["skill_id"]
+        if key not in seen:
+            seen.add(key)
+            unique.append(s)
+
+    return unique[:3]

--- a/backend/app/services/skills/executor.py
+++ b/backend/app/services/skills/executor.py
@@ -1,0 +1,299 @@
+import json
+import logging
+from typing import AsyncGenerator
+
+from ..ai.client import get_client, get_model
+from ...db.crud import get_memory
+from ...db.crud.skills import (
+    get_skill_for_execution,
+    create_execution,
+    update_execution_completed,
+    update_execution_failed,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def extract_content(memory: dict) -> tuple[str, str]:
+    """Extract text content from memory with fallback chain.
+
+    Returns (content, source_name) where source_name is
+    "content", "transcript", "summary", or "none".
+    """
+    if memory.get("content"):
+        return memory["content"], "content"
+    if memory.get("transcript"):
+        return memory["transcript"], "transcript"
+    if memory.get("summary"):
+        return memory["summary"], "summary"
+    return "", "none"
+
+
+def validate_parameters(
+    parameters: dict,
+    skill_params_def: list[dict],
+) -> tuple[dict, list[str]]:
+    """Validate and normalize parameters against skill definition.
+
+    Returns (normalized_params, errors).
+    """
+    normalized = {}
+    errors = []
+
+    for param_def in skill_params_def:
+        pid = param_def["id"]
+        ptype = param_def.get("type", "string")
+
+        if pid in parameters:
+            value = parameters[pid]
+
+            if ptype == "select":
+                options = param_def.get("options", [])
+                if value not in options:
+                    errors.append(f"Parameter '{pid}': value '{value}' not in options {options}")
+                    continue
+            elif ptype == "boolean":
+                if not isinstance(value, bool):
+                    value = str(value).lower() in ("true", "1", "yes")
+            elif ptype == "number":
+                try:
+                    value = float(value) if isinstance(value, str) else value
+                except (ValueError, TypeError):
+                    errors.append(f"Parameter '{pid}': invalid number '{value}'")
+                    continue
+
+            normalized[pid] = value
+        else:
+            normalized[pid] = param_def.get("default")
+
+    return normalized, errors
+
+
+def render_template(
+    template: str,
+    content: str,
+    memory: dict,
+    parameters: dict,
+    skill_params_def: list[dict],
+) -> str:
+    """Replace {{variable}} placeholders in the user template."""
+    result = template
+
+    # Memory variables
+    result = result.replace("{{content}}", content)
+    result = result.replace("{{memory_title}}", memory.get("title") or "")
+    result = result.replace("{{memory_url}}", memory.get("url") or "")
+    result = result.replace("{{memory_date}}", memory.get("created_at") or "")
+    result = result.replace("{{memory_type}}", memory.get("type") or "")
+
+    # Tags as comma-separated string
+    tags = memory.get("tags", [])
+    tag_names = [t["name"] for t in tags] if tags else []
+    result = result.replace("{{memory_tags}}", ", ".join(tag_names))
+
+    # Parameter variables
+    for param_def in skill_params_def:
+        param_id = param_def["id"]
+        value = parameters.get(param_id, param_def.get("default"))
+
+        if param_def.get("type") == "boolean" and isinstance(value, bool):
+            value = "yes" if value else "no"
+
+        result = result.replace(f"{{{{{param_id}}}}}", str(value) if value is not None else "")
+
+    return result
+
+
+async def _stream_llm(
+    prompt_system: str,
+    prompt_user_template: str,
+    params_def: list[dict],
+    memory_id: int,
+    parameters: dict,
+    execution_id: int | None = None,
+    output_format: str = "markdown",
+) -> AsyncGenerator[dict, None]:
+    """Shared streaming logic for execute and test_execute.
+
+    If execution_id is None, no DB tracking is performed.
+    """
+    # 1. Load memory
+    memory = await get_memory(memory_id)
+    if not memory:
+        yield {"type": "error", "message": f"Memory not found: {memory_id}"}
+        return
+
+    # 2. Extract content
+    content, content_source = extract_content(memory)
+    if not content:
+        yield {"type": "error", "message": "Memory has no content, transcript, or summary"}
+        return
+
+    # 3. Validate parameters
+    normalized_params, param_errors = validate_parameters(parameters, params_def)
+    if param_errors:
+        yield {"type": "error", "message": f"Invalid parameters: {'; '.join(param_errors)}"}
+        return
+
+    # 4. Yield meta event
+    meta = {"type": "meta", "content_source": content_source}
+    if execution_id is not None:
+        meta["execution_id"] = execution_id
+    yield meta
+
+    if content_source == "summary":
+        yield {"type": "meta", "content_warning": "summary_only"}
+
+    # 5. Render template
+    rendered_prompt = render_template(
+        template=prompt_user_template,
+        content=content,
+        memory=memory,
+        parameters=normalized_params,
+        skill_params_def=params_def,
+    )
+
+    # 6. Apply output format instruction
+    effective_system = prompt_system
+    if output_format and output_format != "markdown":
+        format_instructions = {
+            "plain": "\n\nIMPORTANT: Respond in plain text only. Do not use any markdown formatting (no headers, bold, italic, lists, code blocks, etc.).",
+            "json": "\n\nIMPORTANT: Respond with valid JSON only. No markdown, no explanation outside the JSON structure.",
+            "html": "\n\nIMPORTANT: Respond with HTML markup. Use semantic HTML tags for structure.",
+        }
+        if output_format in format_instructions:
+            effective_system += format_instructions[output_format]
+
+    # 7. Stream LLM
+    full_result = ""
+    try:
+        client = await get_client()
+        model = get_model()
+
+        messages = [
+            {"role": "system", "content": effective_system},
+            {"role": "user", "content": rendered_prompt},
+        ]
+
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            stream=True,
+        )
+
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                token = chunk.choices[0].delta.content
+                full_result += token
+                yield {"type": "token", "content": token}
+
+        # Mark completed if tracking
+        if execution_id is not None:
+            await update_execution_completed(execution_id, full_result)
+
+        done_event = {"type": "done"}
+        if execution_id is not None:
+            done_event["execution_id"] = execution_id
+        yield done_event
+
+    except Exception as e:
+        error_msg = str(e)
+        logger.error(f"Skill execution failed: {error_msg}")
+        if execution_id is not None:
+            await update_execution_failed(execution_id, error_msg)
+        yield {"type": "error", "message": error_msg}
+
+
+async def execute_skill(
+    skill_id: str,
+    memory_id: int,
+    parameters: dict | None = None,
+    trigger_type: str = "manual",
+) -> AsyncGenerator[dict, None]:
+    """Execute a skill against a memory, yielding SSE event dicts.
+
+    Yields dicts with 'type' key:
+    - {"type": "meta", "execution_id": int, "skill_name": str, "content_source": str}
+    - {"type": "meta", "content_warning": "summary_only"}
+    - {"type": "token", "content": str}
+    - {"type": "done", "execution_id": int}
+    - {"type": "error", "message": str}
+    """
+    parameters = parameters or {}
+
+    # 1. Load skill
+    skill = await get_skill_for_execution(skill_id)
+    if not skill:
+        yield {"type": "error", "message": f"Skill not found: {skill_id}"}
+        return
+
+    # 2. Check input.accepts
+    input_accepts_raw = skill.get("input_accepts")
+    if input_accepts_raw:
+        memory = await get_memory(memory_id)
+        if memory:
+            accepts = json.loads(input_accepts_raw) if isinstance(input_accepts_raw, str) else input_accepts_raw
+            if accepts and memory["type"] not in accepts:
+                yield {"type": "error", "message": f"Skill does not accept memory type '{memory['type']}'"}
+                return
+
+    # 3. Parse parameter definitions
+    params_def_raw = skill.get("parameters")
+    params_def = json.loads(params_def_raw) if isinstance(params_def_raw, str) and params_def_raw else []
+
+    # 4. Create execution entry
+    execution_id = await create_execution(
+        skill_id=skill_id,
+        memory_id=memory_id,
+        trigger_type=trigger_type,
+        parameters=parameters,
+    )
+
+    # 5. Delegate to shared streaming logic
+    async for event in _stream_llm(
+        prompt_system=skill["prompt_system"],
+        prompt_user_template=skill["prompt_user_template"],
+        params_def=params_def,
+        memory_id=memory_id,
+        parameters=parameters,
+        execution_id=execution_id,
+        output_format=skill.get("output_format", "markdown"),
+    ):
+        # Inject skill_name into the first meta event
+        if event.get("type") == "meta" and "content_source" in event:
+            event["skill_name"] = skill["name"]
+        yield event
+
+
+async def test_execute(
+    memory_id: int,
+    prompt_system: str,
+    prompt_user_template: str,
+    parameters_def: list[dict] | None = None,
+    parameter_values: dict | None = None,
+    input_accepts: list[str] | None = None,
+    output_format: str = "markdown",
+) -> AsyncGenerator[dict, None]:
+    """Test-execute with provided prompt data, no DB tracking.
+
+    Same streaming output as execute_skill but does not create a skill_executions entry.
+    """
+    # Check input.accepts if provided
+    if input_accepts:
+        memory = await get_memory(memory_id)
+        if memory and memory["type"] not in input_accepts:
+            yield {"type": "error", "message": f"Skill does not accept memory type '{memory['type']}'"}
+            return
+
+    params_def = parameters_def or []
+
+    async for event in _stream_llm(
+        prompt_system=prompt_system,
+        prompt_user_template=prompt_user_template,
+        params_def=params_def,
+        memory_id=memory_id,
+        parameters=parameter_values or {},
+        execution_id=None,
+        output_format=output_format,
+    ):
+        yield event

--- a/backend/app/services/skills/registry.py
+++ b/backend/app/services/skills/registry.py
@@ -1,0 +1,304 @@
+import json
+import re
+import uuid
+import logging
+from pathlib import Path
+from sqlalchemy import Connection, text
+
+logger = logging.getLogger(__name__)
+
+BUILTIN_SKILLS_DIR = Path(__file__).parent.parent.parent / "skills" / "builtin"
+
+REQUIRED_FIELDS = ["schema_version", "id", "name", "description", "icon", "version"]
+MAX_LOGO_SIZE = 32 * 1024  # 32 KB
+
+
+def validate_skill(data: dict, filename: str) -> list[str]:
+    """Validate a .think-skill file. Returns list of error strings (empty = valid)."""
+    errors = []
+
+    for field in REQUIRED_FIELDS:
+        if field not in data:
+            errors.append(f"{filename}: missing required field '{field}'")
+
+    if "id" in data:
+        try:
+            uuid.UUID(data["id"], version=4)
+        except ValueError:
+            errors.append(f"{filename}: invalid UUID v4 '{data['id']}'")
+
+    prompt = data.get("prompt", {})
+    if "system" not in prompt:
+        errors.append(f"{filename}: missing prompt.system")
+    if "user_template" not in prompt:
+        errors.append(f"{filename}: missing prompt.user_template")
+    elif "{{content}}" not in prompt.get("user_template", ""):
+        errors.append(f"{filename}: prompt.user_template must contain {{{{content}}}}")
+
+    logo = data.get("logo")
+    if logo and len(logo.encode("utf-8")) > MAX_LOGO_SIZE:
+        errors.append(f"{filename}: logo exceeds {MAX_LOGO_SIZE} bytes")
+
+    return errors
+
+
+def validate_skill_json(json_str: str) -> tuple[bool, list[str], list[str], dict | None]:
+    """Validate a .think-skill JSON string for import/editor use.
+
+    Returns (valid, errors, warnings, parsed_dict_or_none).
+    """
+    errors = []
+    warnings = []
+
+    # 1. Parse JSON
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        return False, [f"Invalid JSON: {e}"], [], None
+
+    if not isinstance(data, dict):
+        return False, ["JSON root must be an object"], [], None
+
+    # 2. Required fields
+    for field in REQUIRED_FIELDS:
+        if field not in data:
+            errors.append(f"Missing required field: {field}")
+
+    # 3. UUID validation
+    if "id" in data:
+        try:
+            uuid.UUID(data["id"], version=4)
+        except ValueError:
+            errors.append(f"Invalid UUID v4: {data['id']}")
+
+    # 4. Schema version check
+    sv = data.get("schema_version")
+    if sv is not None and sv != 1:
+        errors.append(f"Unsupported schema_version: {sv} (only v1 supported)")
+
+    # 5. Prompt validation
+    prompt = data.get("prompt", {})
+    if not isinstance(prompt, dict):
+        errors.append("'prompt' must be an object")
+    else:
+        if "system" not in prompt:
+            errors.append("Missing required field: prompt.system")
+        if "user_template" not in prompt:
+            errors.append("Missing required field: prompt.user_template")
+        elif "{{content}}" not in prompt.get("user_template", ""):
+            errors.append("prompt.user_template must contain {{content}}")
+
+    # 6. Logo size
+    logo = data.get("logo")
+    if logo:
+        logo_size = len(logo.encode("utf-8"))
+        if logo_size > MAX_LOGO_SIZE:
+            errors.append(f"Logo exceeds {MAX_LOGO_SIZE} bytes ({logo_size} bytes)")
+        elif logo_size > int(MAX_LOGO_SIZE * 0.875):
+            warnings.append(f"Logo is close to size limit ({logo_size} of {MAX_LOGO_SIZE} bytes)")
+
+    # 7. Parameter validation
+    params = data.get("parameters", [])
+    if params and isinstance(params, list):
+        param_ids = set()
+        for i, p in enumerate(params):
+            pid = p.get("id")
+            if not pid:
+                errors.append(f"Parameter at index {i}: missing 'id'")
+            elif pid in param_ids:
+                errors.append(f"Duplicate parameter id: '{pid}'")
+            else:
+                param_ids.add(pid)
+
+            ptype = p.get("type", "string")
+            if ptype == "select":
+                options = p.get("options", [])
+                if not options:
+                    errors.append(f"Parameter '{pid}': select type requires at least 1 option")
+                default = p.get("default")
+                if default is not None and options and default not in options:
+                    errors.append(f"Parameter '{pid}': default '{default}' not in options")
+            elif ptype == "boolean":
+                default = p.get("default")
+                if default is not None and not isinstance(default, bool):
+                    errors.append(f"Parameter '{pid}': boolean default must be true/false")
+
+    # 8. Check template variable references
+    template = prompt.get("user_template", "") if isinstance(prompt, dict) else ""
+    if template and params and isinstance(params, list):
+        referenced_vars = set(re.findall(r"\{\{(\w+)\}\}", template))
+        builtin_vars = {"content", "memory_title", "memory_url", "memory_date", "memory_type", "memory_tags"}
+        param_ids_set = {p.get("id") for p in params if p.get("id")}
+        unknown = referenced_vars - builtin_vars - param_ids_set
+        for var in sorted(unknown):
+            warnings.append(f"Template references unknown variable: {{{{{var}}}}}")
+
+    valid = len(errors) == 0
+    return valid, errors, warnings, data if valid else None
+
+
+def generate_skill_json(skill_row: dict) -> str:
+    """Generate .think-skill JSON from DB columns.
+
+    Args:
+        skill_row: Dict with Skill table column values.
+
+    Returns:
+        Formatted JSON string matching the .think-skill file format.
+    """
+    tags = skill_row.get("tags")
+    if isinstance(tags, str):
+        tags = json.loads(tags)
+    elif tags is None:
+        tags = []
+
+    input_accepts = skill_row.get("input_accepts")
+    if isinstance(input_accepts, str):
+        input_accepts = json.loads(input_accepts)
+
+    parameters = skill_row.get("parameters")
+    if isinstance(parameters, str):
+        parameters = json.loads(parameters)
+    elif parameters is None:
+        parameters = []
+
+    triggers = skill_row.get("triggers")
+    if isinstance(triggers, str) and triggers:
+        triggers = json.loads(triggers)
+
+    skill_json = {
+        "schema_version": skill_row.get("schema_version", 1),
+        "id": skill_row["id"],
+        "name": skill_row["name"],
+        "description": skill_row["description"],
+        "icon": skill_row["icon"],
+        "version": skill_row.get("version", "1.0.0"),
+        "category": skill_row.get("category", "custom"),
+        "tags": tags,
+        "input": {
+            "type": skill_row.get("input_type", "single_memory"),
+            "accepts": input_accepts,
+        },
+        "parameters": parameters,
+        "prompt": {
+            "system": skill_row["prompt_system"],
+            "user_template": skill_row["prompt_user_template"],
+        },
+        "output": {
+            "format": skill_row.get("output_format", "markdown"),
+        },
+    }
+
+    # Optional fields
+    logo = skill_row.get("logo")
+    if logo:
+        skill_json["logo"] = logo
+
+    author_name = skill_row.get("author_name")
+    author_url = skill_row.get("author_url")
+    if author_name or author_url:
+        skill_json["author"] = {}
+        if author_name:
+            skill_json["author"]["name"] = author_name
+        if author_url:
+            skill_json["author"]["url"] = author_url
+
+    if triggers:
+        skill_json["triggers"] = triggers
+
+    return json.dumps(skill_json, indent=2, ensure_ascii=False)
+
+
+def seed_builtin_skills(conn: Connection) -> None:
+    """Load .think-skill files from builtin/ dir, validate, and upsert into DB.
+
+    Called from init_db() after run_migrations().
+    Uses raw SQL (text()) because this runs in the same Connection as migrations.
+    """
+    if not BUILTIN_SKILLS_DIR.exists():
+        logger.warning(f"Builtin skills directory not found: {BUILTIN_SKILLS_DIR}")
+        return
+
+    skill_files = list(BUILTIN_SKILLS_DIR.glob("*.think-skill"))
+    if not skill_files:
+        logger.info("No builtin skill files found")
+        return
+
+    for filepath in skill_files:
+        try:
+            raw = filepath.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (json.JSONDecodeError, IOError) as e:
+            logger.error(f"Failed to load {filepath.name}: {e}")
+            continue
+
+        errors = validate_skill(data, filepath.name)
+        if errors:
+            for err in errors:
+                logger.error(f"Skill validation: {err}")
+            continue
+
+        prompt = data.get("prompt", {})
+        input_config = data.get("input", {})
+        author = data.get("author", {})
+
+        params = {
+            "id": data["id"],
+            "schema_version": data.get("schema_version", 1),
+            "name": data["name"],
+            "description": data["description"],
+            "icon": data["icon"],
+            "logo": data.get("logo"),
+            "version": data["version"],
+            "category": data.get("category", "custom"),
+            "tags": json.dumps(data.get("tags", [])),
+            "author_name": author.get("name"),
+            "author_url": author.get("url"),
+            "input_type": input_config.get("type", "single_memory"),
+            "input_accepts": json.dumps(input_config.get("accepts")) if input_config.get("accepts") else None,
+            "parameters": json.dumps(data.get("parameters", [])),
+            "prompt_system": prompt["system"],
+            "prompt_user_template": prompt["user_template"],
+            "output_format": data.get("output", {}).get("format", "markdown"),
+            "triggers": json.dumps(data.get("triggers")) if data.get("triggers") else None,
+            "definition": raw,
+        }
+
+        existing = conn.execute(
+            text("SELECT id FROM skills WHERE id = :id"),
+            {"id": data["id"]}
+        ).fetchone()
+
+        if existing:
+            conn.execute(text("""
+                UPDATE skills SET
+                    schema_version = :schema_version, name = :name, description = :description,
+                    icon = :icon, logo = :logo, version = :version, category = :category,
+                    tags = :tags, author_name = :author_name, author_url = :author_url,
+                    input_type = :input_type, input_accepts = :input_accepts,
+                    parameters = :parameters, prompt_system = :prompt_system,
+                    prompt_user_template = :prompt_user_template, output_format = :output_format,
+                    triggers = :triggers, definition = :definition,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+            """), params)
+            logger.info(f"Updated builtin skill: {data['name']}")
+        else:
+            params["source"] = "builtin"
+            params["hidden"] = 0
+            conn.execute(text("""
+                INSERT INTO skills (
+                    id, schema_version, name, description, icon, logo, version,
+                    category, tags, author_name, author_url, input_type, input_accepts,
+                    parameters, prompt_system, prompt_user_template, output_format,
+                    triggers, source, hidden, definition, created_at, updated_at
+                ) VALUES (
+                    :id, :schema_version, :name, :description, :icon, :logo, :version,
+                    :category, :tags, :author_name, :author_url, :input_type, :input_accepts,
+                    :parameters, :prompt_system, :prompt_user_template, :output_format,
+                    :triggers, :source, :hidden, :definition, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+            """), params)
+            logger.info(f"Seeded new builtin skill: {data['name']}")
+
+    conn.commit()

--- a/backend/app/services/skills/triggers.py
+++ b/backend/app/services/skills/triggers.py
@@ -1,0 +1,263 @@
+"""Trigger-Engine: automatic skill execution when memories are saved."""
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+
+from ...events import event_manager, MemoryEvent, EventType
+from ...db.crud.skills import (
+    get_enabled_triggers,
+    get_skill_for_execution,
+    create_execution,
+    update_trigger_stats,
+)
+from ...db.crud import get_memory
+from .executor import _stream_llm
+
+logger = logging.getLogger(__name__)
+
+# Concurrency limit for simultaneous trigger executions
+MAX_CONCURRENT_EXECUTIONS = 3
+
+
+class TriggerEvaluator:
+    """Evaluates trigger rules against memories and executes matching skills."""
+
+    def __init__(self):
+        self._running = False
+        self._queue = None
+        self._task = None
+        self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_EXECUTIONS)
+
+    async def start(self):
+        """Subscribe to MEMORY_PROCESSED events and begin listening."""
+        if self._running:
+            return
+        self._running = True
+        self._queue = event_manager.subscribe()
+        self._task = asyncio.create_task(self._listen())
+        logger.info("TriggerEvaluator started")
+
+    async def stop(self):
+        """Unsubscribe and stop listening."""
+        self._running = False
+        if self._queue:
+            event_manager.unsubscribe(self._queue)
+            self._queue = None
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("TriggerEvaluator stopped")
+
+    async def _listen(self):
+        """Event loop: evaluate triggers for each processed memory."""
+        while self._running:
+            try:
+                event = await self._queue.get()
+                if event.type == EventType.MEMORY_PROCESSED:
+                    await self._evaluate(event.memory_id, event.data)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"TriggerEvaluator error: {e}")
+
+    async def _evaluate(self, memory_id: int, memory_data: dict | None):
+        """Find matching triggers and execute skills."""
+        try:
+            memory = memory_data or await get_memory(memory_id)
+            if not memory:
+                return
+
+            triggers = await get_enabled_triggers()
+            if not triggers:
+                return
+
+            for trigger in triggers:
+                try:
+                    conditions = trigger["conditions"]  # Already parsed by CRUD
+                    if evaluate_conditions(conditions, memory):
+                        asyncio.create_task(
+                            self._execute_trigger(trigger, memory_id)
+                        )
+                except Exception as e:
+                    logger.error(f"Failed to evaluate trigger {trigger['id']}: {e}")
+
+        except Exception as e:
+            logger.error(f"TriggerEvaluator._evaluate failed for memory {memory_id}: {e}")
+
+    async def _execute_trigger(self, trigger: dict, memory_id: int):
+        """Execute a single trigger's skill with concurrency limiting."""
+        async with self._semaphore:
+            trigger_id = trigger["id"]
+            skill_id = trigger["skill_id"]
+            skill_name = trigger.get("skill_name", "Unknown Skill")
+            trigger_name = trigger["name"]
+
+            try:
+                skill = await get_skill_for_execution(skill_id)
+                if not skill:
+                    logger.warning(f"Trigger {trigger_id}: skill {skill_id} not found")
+                    return
+
+                params_def_raw = skill.get("parameters")
+                params_def = json.loads(params_def_raw) if isinstance(params_def_raw, str) and params_def_raw else []
+                parameters = trigger.get("parameters") or {}
+
+                execution_id = await create_execution(
+                    skill_id=skill_id,
+                    memory_id=memory_id,
+                    trigger_type="on_save",
+                    parameters=parameters,
+                )
+
+                # Stream LLM and collect result (background, no SSE needed)
+                had_error = False
+                async for event in _stream_llm(
+                    prompt_system=skill["prompt_system"],
+                    prompt_user_template=skill["prompt_user_template"],
+                    params_def=params_def,
+                    memory_id=memory_id,
+                    parameters=parameters,
+                    execution_id=execution_id,
+                    output_format=skill.get("output_format", "markdown"),
+                ):
+                    if event["type"] == "error":
+                        had_error = True
+                        logger.error(f"Trigger {trigger_id} execution error: {event['message']}")
+                        break
+
+                if not had_error:
+                    await update_trigger_stats(trigger_id)
+
+                    # Notify frontend via SSE
+                    await event_manager.publish(
+                        MemoryEvent(
+                            type=EventType.SKILL_EXECUTED,
+                            memory_id=memory_id,
+                            data={
+                                "execution_id": execution_id,
+                                "skill_id": skill_id,
+                                "skill_name": skill_name,
+                                "skill_icon": trigger.get("skill_icon", ""),
+                                "trigger_name": trigger_name,
+                                "trigger_type": "on_save",
+                            },
+                        )
+                    )
+                    logger.info(
+                        f"Trigger '{trigger_name}' executed skill '{skill_name}' "
+                        f"on memory {memory_id} (execution {execution_id})"
+                    )
+
+            except Exception as e:
+                logger.error(f"Trigger {trigger_id} failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Condition evaluation (pure functions, used by both evaluator and preview)
+# ---------------------------------------------------------------------------
+
+def evaluate_conditions(conditions: dict, memory: dict) -> bool:
+    """Evaluate a conditions dict against a memory dict. Returns True if match."""
+    operator = conditions.get("operator", "AND")
+    rules = conditions.get("rules", [])
+
+    if not rules:
+        return False
+
+    results = [_eval_rule(rule, memory) for rule in rules]
+
+    if operator == "AND":
+        return all(results)
+    return any(results)  # OR
+
+
+def _eval_rule(rule: dict, memory: dict) -> bool:
+    """Evaluate a single condition rule."""
+    field = rule.get("field", "")
+    op = rule.get("op", "")
+    expected = rule.get("value")
+
+    actual = _get_field_value(field, memory)
+
+    try:
+        if op == "equals":
+            return _normalize(actual) == _normalize(expected)
+        elif op == "not_equals":
+            return _normalize(actual) != _normalize(expected)
+        elif op == "contains":
+            if isinstance(actual, list):
+                names = [t["name"] if isinstance(t, dict) else str(t) for t in actual]
+                return str(expected).lower() in [n.lower() for n in names]
+            return str(expected).lower() in str(actual).lower()
+        elif op == "not_contains":
+            if isinstance(actual, list):
+                names = [t["name"] if isinstance(t, dict) else str(t) for t in actual]
+                return str(expected).lower() not in [n.lower() for n in names]
+            return str(expected).lower() not in str(actual).lower()
+        elif op == "starts_with":
+            return str(actual).lower().startswith(str(expected).lower())
+        elif op == "greater_than":
+            return _to_number(actual) > _to_number(expected)
+        elif op == "less_than":
+            return _to_number(actual) < _to_number(expected)
+        elif op == "is_empty":
+            return actual is None or actual == "" or actual == [] or actual == 0
+        elif op == "is_not_empty":
+            return actual is not None and actual != "" and actual != [] and actual != 0
+        else:
+            logger.warning(f"Unknown operator: {op}")
+            return False
+    except Exception as e:
+        logger.warning(f"Rule evaluation error ({field} {op} {expected}): {e}")
+        return False
+
+
+def _get_field_value(field: str, memory: dict):
+    """Extract a field value from a memory dict for condition evaluation."""
+    if field == "type":
+        return memory.get("type", "")
+    elif field == "tags":
+        return memory.get("tags", [])
+    elif field == "title":
+        return memory.get("title", "")
+    elif field == "url":
+        return memory.get("url", "")
+    elif field == "content_length":
+        content = memory.get("content", "")
+        return len(content) if content else 0
+    elif field == "has_transcript":
+        transcript = memory.get("transcript")
+        return bool(transcript and transcript.strip())
+    elif field == "media_source":
+        return memory.get("media_source", "")
+    else:
+        return memory.get(field)
+
+
+def _normalize(value) -> str:
+    """Normalize a value to lowercase string for comparison."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value).lower().strip()
+
+
+def _to_number(value) -> float:
+    """Convert a value to a number for comparison."""
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+# Global instance
+trigger_evaluator = TriggerEvaluator()

--- a/backend/app/skills/builtin/export-to-markdown.think-skill
+++ b/backend/app/skills/builtin/export-to-markdown.think-skill
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+
+  "id": "a1b2c3d4-0003-4000-a000-000000000003",
+  "name": "Export to Markdown",
+  "description": "Convert saved content to clean, portable Markdown with optional metadata",
+  "icon": "\ud83d\udcdd",
+  "logo": null,
+  "version": "1.0.0",
+  "category": "export",
+  "tags": ["markdown", "export", "formatting"],
+
+  "author": {
+    "name": "ThinkOS Team",
+    "url": "https://github.com/ThinkFoundation"
+  },
+
+  "input": {
+    "type": "single_memory",
+    "accepts": ["web", "note", "voice_memo", "audio", "video", "document"]
+  },
+
+  "parameters": [
+    {
+      "id": "include_metadata",
+      "label": "Include Metadata Header",
+      "description": "Add a YAML-style metadata header with title, source URL, date, and tags",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "id": "clean_formatting",
+      "label": "Clean Up Formatting",
+      "description": "Remove artifacts, fix headings, and normalize whitespace for clean output",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+
+  "prompt": {
+    "system": "You are a formatting assistant that converts content into clean, well-structured Markdown. Preserve all information but improve readability. Fix broken formatting, normalize headings, and ensure consistent style. Do not add, remove, or change any facts.",
+    "user_template": "Convert the following content to clean Markdown.\n\nInclude metadata header: {{include_metadata}}\nClean up formatting: {{clean_formatting}}\n\nTitle: {{memory_title}}\nSource: {{memory_url}}\nDate: {{memory_date}}\nType: {{memory_type}}\nTags: {{memory_tags}}\n\n---\n\n{{content}}"
+  },
+
+  "output": {
+    "format": "markdown"
+  },
+
+  "triggers": {
+    "chat": {
+      "patterns": ["export", "markdown", "convert to md", "exportieren"],
+      "intent_description": "User wants to export or convert content to Markdown format",
+      "auto_parameters": {
+        "include_metadata": true,
+        "clean_formatting": true
+      }
+    }
+  }
+}

--- a/backend/app/skills/builtin/extract-action-items.think-skill
+++ b/backend/app/skills/builtin/extract-action-items.think-skill
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+
+  "id": "a1b2c3d4-0001-4000-a000-000000000001",
+  "name": "Extract Action Items",
+  "description": "Pull todos, decisions, and follow-ups from meeting notes or any text containing tasks",
+  "icon": "\u2705",
+  "logo": null,
+  "version": "1.0.0",
+  "category": "productivity",
+  "tags": ["meetings", "todos", "action-items"],
+
+  "author": {
+    "name": "ThinkOS Team",
+    "url": "https://github.com/ThinkFoundation"
+  },
+
+  "input": {
+    "type": "single_memory",
+    "accepts": ["web", "note", "voice_memo", "audio", "video", "document"]
+  },
+
+  "parameters": [
+    {
+      "id": "format",
+      "label": "Output Format",
+      "description": "How the extracted action items should be organized in the output",
+      "type": "select",
+      "options": ["grouped", "flat", "by-person"],
+      "default": "grouped"
+    },
+    {
+      "id": "include_deadlines",
+      "label": "Extract Deadlines",
+      "description": "Attempt to identify and include deadlines mentioned for each item",
+      "type": "boolean",
+      "default": true
+    }
+  ],
+
+  "prompt": {
+    "system": "You are a precise assistant that extracts action items from text. For each item identify: the task, the responsible person (if mentioned), the deadline (if mentioned), and the priority (high/medium/low, only if clearly inferrable). Be thorough but never invent items that aren't stated or clearly implied. Output as clean Markdown.",
+    "user_template": "Extract all action items from the following content.\n\nOutput format: {{format}}\nInclude deadlines: {{include_deadlines}}\n\n---\n\n{{content}}"
+  },
+
+  "output": {
+    "format": "markdown"
+  },
+
+  "triggers": {
+    "chat": {
+      "patterns": ["action items", "todos", "aufgaben", "next steps", "follow-ups"],
+      "intent_description": "User wants to extract tasks or action items from content",
+      "auto_parameters": {
+        "format": "grouped",
+        "include_deadlines": true
+      }
+    },
+    "auto": {
+      "suggested_rules": [
+        {
+          "name": "Meeting Notes \u2192 Action Items",
+          "description": "Automatically extract action items when meeting notes are saved",
+          "conditions": {
+            "operator": "AND",
+            "rules": [
+              { "field": "detected_type", "operator": "equals", "value": "meeting_notes" }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/backend/app/skills/builtin/generate-insights.think-skill
+++ b/backend/app/skills/builtin/generate-insights.think-skill
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+
+  "id": "a1b2c3d4-0002-4000-a000-000000000002",
+  "name": "Generate Insights",
+  "description": "Surface key themes, patterns, and takeaways from any saved content",
+  "icon": "\ud83d\udca1",
+  "logo": null,
+  "version": "1.0.0",
+  "category": "analysis",
+  "tags": ["themes", "patterns", "takeaways"],
+
+  "author": {
+    "name": "ThinkOS Team",
+    "url": "https://github.com/ThinkFoundation"
+  },
+
+  "input": {
+    "type": "single_memory",
+    "accepts": ["web", "note", "voice_memo", "audio", "video", "document"]
+  },
+
+  "parameters": [
+    {
+      "id": "depth",
+      "label": "Analysis Depth",
+      "description": "How thorough the analysis should be",
+      "type": "select",
+      "options": ["quick", "detailed", "comprehensive"],
+      "default": "detailed"
+    },
+    {
+      "id": "focus",
+      "label": "Focus Area",
+      "description": "Which aspects to prioritize in the analysis",
+      "type": "select",
+      "options": ["general", "trends", "risks", "opportunities"],
+      "default": "general"
+    }
+  ],
+
+  "prompt": {
+    "system": "You are an analytical assistant that identifies key insights from content. You surface themes, patterns, notable points, and actionable takeaways. Be specific and reference the source material. Output as clean Markdown with clear headings.",
+    "user_template": "Analyze the following content and generate insights.\n\nAnalysis depth: {{depth}}\nFocus area: {{focus}}\n\n---\n\n{{content}}"
+  },
+
+  "output": {
+    "format": "markdown"
+  },
+
+  "triggers": {
+    "chat": {
+      "patterns": ["insights", "analyze", "key points", "takeaways", "erkenntnisse"],
+      "intent_description": "User wants to extract insights or key themes from content",
+      "auto_parameters": {
+        "depth": "detailed",
+        "focus": "general"
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
 
   app:
     dependencies:
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
+      '@emoji-mart/react':
+        specifier: ^1.1.1
+        version: 1.1.1(emoji-mart@5.6.0)(react@18.3.1)
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
@@ -465,6 +471,15 @@ packages:
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
+
+  '@emoji-mart/react@1.1.1':
+    resolution: {integrity: sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==}
+    peerDependencies:
+      emoji-mart: ^5.2
+      react: ^16.8 || ^17 || ^18
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -689,89 +704,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -882,30 +913,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.88':
     resolution: {integrity: sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.88':
     resolution: {integrity: sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.88':
     resolution: {integrity: sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.88':
     resolution: {integrity: sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.88':
     resolution: {integrity: sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==}
@@ -1317,56 +1353,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -2396,6 +2443,9 @@ packages:
 
   ellipsize@0.5.1:
     resolution: {integrity: sha512-0jEAyuIRU6U8MN0S5yUqIrkK/AQWkChh642N3zQuGV57s9bsUWYLc0jJOoDIUkZ2sbEL3ySq8xfq71BvG4q3hw==}
+
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -5037,6 +5087,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emoji-mart/data@1.2.1': {}
+
+  '@emoji-mart/react@1.1.1(emoji-mart@5.6.0)(react@18.3.1)':
+    dependencies:
+      emoji-mart: 5.6.0
+      react: 18.3.1
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -6950,6 +7007,8 @@ snapshots:
       - supports-color
 
   ellipsize@0.5.1: {}
+
+  emoji-mart@5.6.0: {}
 
   emoji-regex@8.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add complete skill system with 3 built-in skills (Extract Action Items, Generate Insights, Export to Markdown), full CRUD for custom skills, and .think-skill import/export format
- Add trigger engine for automatic skill execution on memory save with condition-based rules (field/operator/value, AND/OR logic) and live preview with match ratios
- Add chat integration with pattern-based skill suggestions and SSE-streamed in-chat execution results
- Add SkillsPage with browse/history tabs, SkillDetail panel, SkillEditor, SkillRunner, and execution history with filtering

## Test plan

- [ ] Open Skills page → verify built-in skills are listed with correct categories and icons
- [ ] Click a skill → verify detail panel shows description, prompt preview, and automation section
- [ ] Create a custom skill via editor → verify it appears in the list
- [ ] Run a skill on a memory → verify SSE streaming output and result saved to execution history
- [ ] Add a trigger with conditions → verify preview shows matching memory count
- [ ] Save a memory matching trigger conditions → verify skill executes automatically
- [ ] Send chat message with source memories containing "key takeaways" → verify skill suggestion chips appear
- [ ] Click a skill chip in chat → verify streamed result renders with gradient header and footer link
- [ ] Verify dark mode for all new components